### PR TITLE
Fix h2gis groovy tests, improve IOMethods.

### DIFF
--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2GIS.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2GIS.java
@@ -62,7 +62,7 @@ import org.orbisgis.datamanager.io.IOMethods;
  * Implementation of the IJdbcDataSource interface dedicated to the usage of an H2/H2GIS database.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2018)
+ * @author Sylvain PALOMINOS (UBS 2018-2019)
  */
 public class H2GIS extends JdbcDataSource {
 
@@ -89,15 +89,14 @@ public class H2GIS extends JdbcDataSource {
     public static H2GIS open(String fileName) {
         File file = URIUtilities.fileFromString(fileName);
         try {
-            if (FileUtil.isFileImportable(file, "properties")) {
+            if (FileUtil.isExtensionWellFormated(file, "properties")) {
                 Properties prop = new Properties();
                 FileInputStream fous = new FileInputStream(file);
                 prop.load(fous);
                 return open(prop);
             }
-        } catch (SQLException | IOException e) {
+        } catch (IOException e) {
             LOGGER.error("Unable to read the properties file.\n" + e.getLocalizedMessage());
-            return null;
         }
         return null;
     }
@@ -238,9 +237,7 @@ public class H2GIS extends JdbcDataSource {
 
     @Override
     public ITableWrapper link(String filePath, String tableName, boolean delete) {
-        H2gisLinked link = new H2gisLinked();
-        link.create(filePath, tableName, delete, this);
-        return link;
+        return new H2gisLinked(filePath, tableName, delete, this);
     }
 
     @Override
@@ -250,9 +247,7 @@ public class H2GIS extends JdbcDataSource {
 
     @Override
     public ITableWrapper link(String filePath, boolean delete) {
-        H2gisLinked link = new H2gisLinked();
-        link.create(filePath, delete, this);
-        return link;
+        return new H2gisLinked(filePath, delete, this);
     }
 
     @Override
@@ -262,9 +257,7 @@ public class H2GIS extends JdbcDataSource {
 
     @Override
     public ITableWrapper load(String filePath, String tableName, String encoding, boolean delete) {
-        H2gisLoad h2gisLoad = new H2gisLoad();
-        h2gisLoad.create(filePath, tableName, encoding, delete, this);
-        return h2gisLoad;
+        return new H2gisLoad(filePath, tableName, encoding, delete, this);
     }
 
     @Override
@@ -284,9 +277,7 @@ public class H2GIS extends JdbcDataSource {
 
     @Override
     public ITableWrapper load(Map<String, String> properties, String inputTableName, String outputTableName, boolean delete) {
-        H2gisLoad h2gisLoad = new H2gisLoad();
-        h2gisLoad.create(properties, inputTableName, outputTableName, delete, this);
-        return h2gisLoad;
+        return new H2gisLoad(properties, inputTableName, outputTableName, delete, this);
 
     }
 
@@ -307,9 +298,7 @@ public class H2GIS extends JdbcDataSource {
 
     @Override
     public ITableWrapper load(String filePath, boolean delete) {
-        H2gisLoad h2gisLoad = new H2gisLoad();
-        h2gisLoad.create(filePath, delete, this);
-        return h2gisLoad;
+        return new H2gisLoad(filePath, delete, this);
     }
 
     /**

--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisLinked.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisLinked.java
@@ -52,7 +52,7 @@ import java.sql.SQLException;
 /**
  * This class is used to link a file or a table to a H2GIS database
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2018)
+ * @author Sylvain PALOMINOS (UBS 2018-2019)
  */
 public class H2gisLinked implements ITableWrapper {
 
@@ -60,8 +60,34 @@ public class H2gisLinked implements ITableWrapper {
     private String tableName;
     private ConnectionWrapper connectionWrapper;
 
-    public H2gisLinked() {
+    /**
+     * Create a dynamic link from a file
+     *
+     * @param filePath the path of the file
+     * @param tableName the name of the table created to store the file
+     * @param delete true to delete the table if exists
+     * @param h2GIS the H2GIS database
+     */
+    public H2gisLinked(String filePath, String tableName, boolean delete, H2GIS h2GIS) {
+        create(filePath, tableName, delete, h2GIS);
+    }
 
+
+    /**
+     * Create a dynamic link from a file
+     *
+     * @param filePath the path of the file
+     * @param delete true to delete the table if exists
+     * @param h2GIS the H2GIS database
+     */
+    public H2gisLinked(String filePath, boolean delete, H2GIS h2GIS) {
+        final String name = URIUtilities.fileFromString(filePath).getName();
+        String tableName = name.substring(0, name.lastIndexOf(".")).toUpperCase();
+        if (tableName.matches("^[a-zA-Z][a-zA-Z0-9_]*$")) {
+            create(filePath, tableName,delete, h2GIS);
+        } else {
+            LOGGER.error("The file name contains unsupported characters");
+        }
     }
 
     @Override
@@ -111,7 +137,7 @@ public class H2gisLinked implements ITableWrapper {
      * @param delete true to delete the table if exists
      * @param h2GIS the H2GIS database
      */
-    public void create(String filePath, String tableName, boolean delete, H2GIS h2GIS) {
+    private void create(String filePath, String tableName, boolean delete, H2GIS h2GIS) {
         this.tableName=tableName;
         this.connectionWrapper =  h2GIS.getConnectionWrapper();
         if(delete){
@@ -126,23 +152,6 @@ public class H2gisLinked implements ITableWrapper {
             h2GIS.execute(String.format("CALL FILE_TABLE('%s','%s')", filePath, tableName));
         } catch (SQLException e) {
             LOGGER.error("Cannot link the file.\n"+e.getLocalizedMessage());
-        }
-    }
-
-    /**
-     * Create a dynamic link from a file
-     *
-     * @param filePath the path of the file
-     * @param delete true to delete the table if exists
-     * @param h2GIS the H2GIS database
-     */
-    public void create(String filePath, boolean delete, H2GIS h2GIS) {
-        final String name = URIUtilities.fileFromString(filePath).getName();
-        String tableName = name.substring(0, name.lastIndexOf(".")).toUpperCase();
-        if (tableName.matches("^[a-zA-Z][a-zA-Z0-9_]*$")) {
-            create(filePath, tableName,delete, h2GIS);
-        } else {
-            LOGGER.error("The file name contains unsupported characters");
         }
     }
 }

--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisLoad.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisLoad.java
@@ -36,19 +36,11 @@
  */
 package org.orbisgis.datamanager.h2gis;
 
-import org.h2gis.api.EmptyProgressVisitor;
-import org.h2gis.functions.io.csv.CSVDriverFunction;
-import org.h2gis.functions.io.dbf.DBFDriverFunction;
-import org.h2gis.functions.io.geojson.GeoJsonReaderDriver;
-import org.h2gis.functions.io.gpx.GPXDriverFunction;
-import org.h2gis.functions.io.shp.SHPDriverFunction;
-import org.h2gis.functions.io.tsv.TSVDriverFunction;
-import org.h2gis.functions.io.utility.FileUtil;
 import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.URIUtilities;
 import org.h2gis.utilities.wrapper.ConnectionWrapper;
 import org.h2gis.utilities.wrapper.StatementWrapper;
-import org.orbisgis.datamanager.h2gis.H2GIS;
+import org.orbisgis.datamanager.io.IOMethods;
 import org.orbisgis.datamanagerapi.dataset.ISpatialTable;
 import org.orbisgis.datamanagerapi.dataset.ITable;
 import org.orbisgis.datamanagerapi.dataset.ITableWrapper;
@@ -56,18 +48,14 @@ import org.osgi.service.jdbc.DataSourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
-import org.h2gis.functions.io.osm.OSMDriverFunction;
 
 /**
  * This class is used to load a file to a H2GIS database
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2018)
+ * @author Sylvain PALOMINOS (UBS 2018-2019)
  */
 public class H2gisLoad implements ITableWrapper {
 
@@ -75,8 +63,47 @@ public class H2gisLoad implements ITableWrapper {
     private String tableName;
     private ConnectionWrapper connectionWrapper;
 
+    /**
+     * Load a table to a H2GIS database from another database
+     *
+     * @param properties external database properties to set up the connection
+     * @param inputTableName the name of the table in the external database
+     * @param outputTableName the name of the table in the H2GIS database
+     * @param delete true to delete the table if exists
+     * @param h2GIS the H2GIS database
+     */
+    public H2gisLoad(Map<String, String> properties, String inputTableName, String outputTableName, boolean delete, H2GIS h2GIS){
+        create(properties, inputTableName, outputTableName, delete, h2GIS);
+    }
 
-    public H2gisLoad() {
+    /**
+     * Load a file to a H2GIS database
+     *
+     * @param filePath the path of the file.
+     * @param delete true to delete the table if exists
+     * @param h2GIS the H2GIS database
+     */
+    public H2gisLoad(String filePath, boolean delete, H2GIS h2GIS) {
+        final String name = URIUtilities.fileFromString(filePath).getName();
+        String tableName = name.substring(0, name.lastIndexOf(".")).toUpperCase();
+        if (tableName.matches("^[a-zA-Z][a-zA-Z0-9_]*$")) {
+            create(filePath,tableName, null, delete,h2GIS);
+        } else {
+            LOGGER.error("Unsupported file characters");
+        }
+    }
+
+    /**
+     * Load a file to a H2GIS database
+     *
+     * @param filePath the path of the file
+     * @param tableName the name of the table created to store the file
+     * @param encoding an encoding value to read the file
+     * @param delete true to delete the table if exists
+     * @param h2GIS the H2GIS database
+     */
+    public H2gisLoad(String filePath, String tableName, String encoding, boolean delete, H2GIS h2GIS) {
+        create(filePath, tableName, encoding, delete, h2GIS);
     }
 
     @Override
@@ -133,104 +160,22 @@ public class H2gisLoad implements ITableWrapper {
      * @param delete true to delete the table if exists
      * @param h2GIS the H2GIS database
      */
-    public void create(String filePath, String tableName, String encoding, boolean delete, H2GIS h2GIS) {
+    private void create(String filePath, String tableName, String encoding, boolean delete, H2GIS h2GIS) {
         this.tableName=tableName;
         this.connectionWrapper =  h2GIS.getConnectionWrapper();
-        File fileToImport = URIUtilities.fileFromString(filePath);
-        try {
-            if (FileUtil.isExtensionWellFormated(fileToImport, "shp")) {
-                deleteTable( delete,  h2GIS);
-                SHPDriverFunction driverFunction = new SHPDriverFunction();
-                driverFunction.importFile(connectionWrapper, tableName, fileToImport, new EmptyProgressVisitor(),encoding);
-            }
-            else if (FileUtil.isExtensionWellFormated(fileToImport, "geojson")) {
-                deleteTable( delete,  h2GIS);
-                GeoJsonReaderDriver driverFunction = new GeoJsonReaderDriver(connectionWrapper, fileToImport);
-                driverFunction.read(new EmptyProgressVisitor(), tableName);
-            }
-            else if (FileUtil.isExtensionWellFormated(fileToImport, "csv")) {
-                deleteTable( delete,  h2GIS);
-                if(encoding==null){
-                    encoding="charset=UTF-8";
-                }
-                CSVDriverFunction driverFunction = new CSVDriverFunction();
-                driverFunction.importFile(connectionWrapper, tableName, fileToImport,new EmptyProgressVisitor(),encoding);
-            }
-            else if (FileUtil.isExtensionWellFormated(fileToImport, "dbf")) {
-                deleteTable( delete,  h2GIS);
-                DBFDriverFunction driverFunction = new DBFDriverFunction();
-                driverFunction.importFile(connectionWrapper, tableName, fileToImport,new EmptyProgressVisitor(),encoding);
-            }
-            else if (FileUtil.isExtensionWellFormated(fileToImport, "tsv")) {
-                deleteTable( delete,  h2GIS);
-                LOGGER.warn("Encoding is not yet supported for this file format");
-                TSVDriverFunction driverFunction = new TSVDriverFunction();
-                driverFunction.importFile(connectionWrapper, tableName, fileToImport,new EmptyProgressVisitor());
-            }
-            else if (FileUtil.isExtensionWellFormated(fileToImport, "osm")||FileUtil.isFileImportable(fileToImport, "gz")||FileUtil.isFileImportable(fileToImport, "bz")) {
-                LOGGER.warn("Encoding is not yet supported for this file format");
-                OSMDriverFunction driverFunction = new OSMDriverFunction();
-                driverFunction.importFile(connectionWrapper, tableName, fileToImport,new EmptyProgressVisitor(),delete);
-                tableName=null;
-            }
-            else if (FileUtil.isExtensionWellFormated(fileToImport, "gpx")) {
-                LOGGER.warn("Encoding is not yet supported for this file format");
-                GPXDriverFunction driverFunction = new GPXDriverFunction();
-                driverFunction.importFile(connectionWrapper, tableName, fileToImport,new EmptyProgressVisitor(),delete);
-                tableName=null;
-            }
-            else{
-                LOGGER.error("Unsupported file format");
-            }
-        } catch (SQLException | FileNotFoundException e) {
-            LOGGER.error("Cannot load.\n"+e.getLocalizedMessage());
-        } catch (IOException e) {
-            LOGGER.error("Cannot load.\n"+e.getLocalizedMessage());
-        }
-    }
-    
-    /**
-     * Method to delete a table
-     *
-     * @param delete true to delete
-     * @param h2GIS the H2GIS database 
-     */
-    private void deleteTable(boolean delete, H2GIS h2GIS) {
-        if (delete) {
-            try {
-                h2GIS.execute("DROP TABLE IF EXISTS " + tableName);
-            } catch (SQLException e) {
-                LOGGER.error("Cannot drop the table.\n" + e.getLocalizedMessage());
-            }
-        }
-    }
-
-    /**
-     * Load a file to a H2GIS database
-     *
-     * @param filePath the path of the file.
-     * @param delete true to delete the table if exists
-     * @param h2GIS the H2GIS database
-     */
-    public void create(String filePath, boolean delete, H2GIS h2GIS) {
-        final String name = URIUtilities.fileFromString(filePath).getName();
-        String tableName = name.substring(0, name.lastIndexOf(".")).toUpperCase();
-        if (tableName.matches("^[a-zA-Z][a-zA-Z0-9_]*$")) {
-            create(filePath,tableName, null, delete,h2GIS);
-        } else {
-            LOGGER.error("Unsupported file characters");
-        }
+        IOMethods.loadFile(filePath, tableName, encoding, delete, h2GIS);
     }
 
     /**
      * Load a table to a H2GIS database from another database
+     *
      * @param properties external database properties to set up the connection
      * @param inputTableName the name of the table in the external database
      * @param outputTableName the name of the table in the H2GIS database
      * @param delete true to delete the table if exists
      * @param h2GIS the H2GIS database
      */
-    public void create(Map<String, String> properties, String inputTableName, String outputTableName, boolean delete, H2GIS h2GIS){
+    private void create(Map<String, String> properties, String inputTableName, String outputTableName, boolean delete, H2GIS h2GIS){
         String user = properties.get(DataSourceFactory.JDBC_USER);
         String password = properties.get(DataSourceFactory.JDBC_PASSWORD);
         String driverName = "";
@@ -238,7 +183,6 @@ public class H2gisLoad implements ITableWrapper {
         if(jdbc_url!=null) {
             if (jdbc_url.startsWith("jdbc:")) {
                 String url = jdbc_url.substring("jdbc:".length());
-                String driverURI = url.substring(url.indexOf(":"));
                 if (url.startsWith("h2")) {
                     driverName = "org.h2.Driver";
                 } else if (url.startsWith("postgresql")) {

--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisSpatialTable.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisSpatialTable.java
@@ -38,6 +38,7 @@ package org.orbisgis.datamanager.h2gis;
 
 import groovy.lang.MetaClass;
 import org.codehaus.groovy.runtime.InvokerHelper;
+import org.h2gis.utilities.JDBCUtilities;
 import org.h2gis.utilities.SpatialResultSetMetaData;
 import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.wrapper.SpatialResultSetImpl;
@@ -51,15 +52,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import org.h2gis.utilities.JDBCUtilities;
 
+/**
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2018-2019)
+ */
 public class H2gisSpatialTable extends SpatialResultSetImpl implements ISpatialTable, IJdbcTable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(H2gisSpatialTable.class);

--- a/data-manager/src/main/java/org/orbisgis/datamanager/postgis/POSTGIS.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/postgis/POSTGIS.java
@@ -201,9 +201,7 @@ public class POSTGIS extends JdbcDataSource {
 
     @Override
     public ITableWrapper load(String filePath, String tableName, String encoding, boolean delete) {
-            PostgisLoad  postgisLoad = new PostgisLoad();
-            postgisLoad.create(filePath,tableName,encoding,delete, this );
-            return postgisLoad;
+        return new PostgisLoad(filePath,tableName,encoding,delete, this);
     }
 
     @Override
@@ -242,9 +240,7 @@ public class POSTGIS extends JdbcDataSource {
 
     @Override
     public ITableWrapper load(String filePath,boolean delete) {
-        PostgisLoad postgisLoad =  new PostgisLoad();
-        postgisLoad.create(filePath, delete, this);
-        return postgisLoad;
+        return new PostgisLoad(filePath, delete, this);
     }
 
     @Override

--- a/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
+++ b/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
@@ -149,7 +149,7 @@ class GroovyH2GISTest {
     void exportImportShpFile() {
         def h2GIS = H2GIS.open([databaseName: './target/loadH2GIS'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS h2gis;
+                DROP TABLE IF EXISTS h2gis, h2gis_imported;
                 CREATE TABLE h2gis (id int, the_geom point);
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
@@ -165,7 +165,7 @@ class GroovyH2GISTest {
     void exportImportTwoTimesShpFile() {
         def h2GIS = H2GIS.open([databaseName: './target/loadH2GIS'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS h2gis;
+                DROP TABLE IF EXISTS h2gis, h2gis_imported;
                 CREATE TABLE h2gis (id int, the_geom point);
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
@@ -182,7 +182,7 @@ class GroovyH2GISTest {
     void exportImportShpFileSimple1() {
         def h2GIS = H2GIS.open([databaseName: './target/loadH2GIS'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS h2gis;
+                DROP TABLE IF EXISTS h2gis, h2gis_imported;
                 CREATE TABLE h2gis (id int, the_geom point);
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
@@ -198,7 +198,7 @@ class GroovyH2GISTest {
     void exportImportShpFileSimple2() {
         def h2GIS = H2GIS.open([databaseName: './target/loadH2GIS'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS h2gis;
+                DROP TABLE IF EXISTS h2gis, h2gis_imported;
                 CREATE TABLE h2gis (id int, the_geom point);
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
@@ -213,14 +213,14 @@ class GroovyH2GISTest {
     void exportImportGeoJsonShapeFile() {
         def h2GIS = H2GIS.open([databaseName: './target/loadH2GIS'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS h2gis;
+                DROP TABLE IF EXISTS h2gis, h2gis_imported;
                 CREATE TABLE h2gis (id int, the_geom point);
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
-        h2GIS.save("h2gis","target/h2gis_imported.geojson");
-        h2GIS.load("target/h2gis_imported.geojson");
-        h2GIS.save("h2gis_imported","target/h2gis_imported.shp");
-        h2GIS.load("target/h2gis_imported.shp", true);
+        h2GIS.save("h2gis","target/h2gis_imported.geojson")
+        h2GIS.load("target/h2gis_imported.geojson")
+        h2GIS.save("h2gis_imported","target/h2gis_imported.shp")
+        h2GIS.load("target/h2gis_imported.shp", true)
         def concat = ""
         h2GIS.getSpatialTable "h2gis_imported" eachRow { row -> concat += "$row.id $row.the_geom $row.geometry\n" }
         assertEquals("1 POINT (10 10) POINT (10 10)\n2 POINT (1 1) POINT (1 1)\n", concat)
@@ -231,15 +231,16 @@ class GroovyH2GISTest {
     void exportImportCSV() {
         def h2GIS = H2GIS.open([databaseName: './target/loadH2GIS'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS h2gis;
+                DROP TABLE IF EXISTS h2gis, h2gis_imported;
                 CREATE TABLE h2gis (id int, the_geom point);
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
-        h2GIS.save("h2gis","target/h2gis_imported.csv");
-        h2GIS.load("target/h2gis_imported.csv");
+        h2GIS.save("h2gis","target/h2gis_imported.csv")
+        h2GIS.load("target/h2gis_imported.csv")
         def concat = ""
-        h2GIS.getSpatialTable "h2gis_imported" eachRow { row -> concat += "$row.id $row.the_geom $row.geometry\n" }
-        assertEquals("1 POINT (10 10) POINT (10 10)\n2 POINT (1 1) POINT (1 1)\n", concat)
+        h2GIS.getSpatialTable "h2gis_imported" eachRow { row ->
+            concat += "$row.id $row.the_geom\n" }
+        assertEquals("1 POINT (10 10)\n2 POINT (1 1)\n", concat)
         println(concat)
     }
     
@@ -298,7 +299,7 @@ class GroovyH2GISTest {
     void linkExternalFileAsTypeAndSave() {
         def h2GIS = H2GIS.open([databaseName: './target/secondH2GIS', user:'sa', password:'sa'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS externalTable;
+                DROP TABLE IF EXISTS externalTable, supersave;
                 CREATE TABLE externalTable (id int, the_geom point);
                 INSERT INTO externalTable VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
@@ -314,7 +315,7 @@ class GroovyH2GISTest {
     void executeQueryBindings() {
         def h2GIS = H2GIS.open([databaseName: './target/loadH2GIS'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS h2gis;
+                DROP TABLE IF EXISTS h2gis, super;
                 CREATE TABLE h2gis (id int, the_geom point);
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
@@ -332,7 +333,7 @@ class GroovyH2GISTest {
     void executeQueryNoBindings() {
         def h2GIS = H2GIS.open([databaseName: './target/loadH2GIS'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS h2gis;
+                DROP TABLE IF EXISTS h2gis, super;
                 CREATE TABLE h2gis (id int, the_geom point);
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
@@ -350,7 +351,7 @@ class GroovyH2GISTest {
     void executeQueryEmptyBindings() {
         def h2GIS = H2GIS.open([databaseName: './target/loadH2GIS'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS h2gis;
+                DROP TABLE IF EXISTS h2gis, super;
                 CREATE TABLE h2gis (id int, the_geom point);
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
@@ -368,17 +369,21 @@ class GroovyH2GISTest {
     void executeQueryBindingsNumeric() {
         def h2GIS = H2GIS.open([databaseName: './target/loadH2GIS'])
         h2GIS.execute("""
-                DROP TABLE IF EXISTS h2gis;
+                DROP TABLE IF EXISTS h2gis, super;
                 CREATE TABLE h2gis (id int, the_geom point);
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
         def file = new File('target/myscript.sql')
-        file.delete();
+        file.delete()
         file << 'CREATE TABLE super as SELECT ST_BUFFER(the_geom, $DISTANCE) as the_geom FROM $BINIOU;'
-        h2GIS.executeScript("target/myscript.sql", [BINIOU:'h2gis', DISTANCE:10]);
+        h2GIS.executeScript("target/myscript.sql", [BINIOU:'h2gis', DISTANCE:10])
         def concat = ""
-        h2GIS.getSpatialTable "super" eachRow { row -> concat += "$row.id $row.the_geom $row.geometry\n" }
-        assertEquals("1 POINT (10 10) POINT (10 10)\n2 POINT (1 1) POINT (1 1)\n", concat)
+        h2GIS.getSpatialTable "super" eachRow { row ->
+            concat += "$row.id $row.the_geom $row.geometry\n"
+            assertNull row.id
+            assertTrue "$row.the_geom".startsWith("POLYGON ((")
+            assertTrue "$row.geometry".startsWith("POLYGON ((")
+        }
         println(concat)
     }
 


### PR DESCRIPTION
Fix h2gis groovy tests (`executeQueryBindingsNumeric` and `exportImportCSV`) and ensure all the sql test drop the table before being executed.
Move the driver call done in the `create` methods into the `IOMethods` class under the method `loadFile`.
Simplify the syntax of the `saveAsFile` and `loadFile` methods thanks to the changes in orbisgis/h2gis#959
Move the creation of the `H2gisLoad`, `H2gisLinked`, `PostgisLoad` from the create method into the constructors. The create method is now private.