### PR TITLE
Improve the sql request building.

### DIFF
--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IJdbcTable.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IJdbcTable.java
@@ -39,6 +39,7 @@ package org.orbisgis.datamanagerapi.dataset;
 import groovy.lang.Closure;
 import groovy.lang.GroovyObject;
 import org.h2gis.utilities.TableLocation;
+import org.orbisgis.datamanagerapi.dsl.IWhereBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IBuilderResult.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IBuilderResult.java
@@ -34,57 +34,38 @@
  * or contact directly:
  * info_at_ orbisgis.org
  */
-package org.orbisgis.datamanagerapi.dataset;
+package org.orbisgis.datamanagerapi.dsl;
+
 
 import groovy.lang.Closure;
-import org.orbisgis.datamanagerapi.dsl.IWhereBuilder;
-
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.util.Collection;
+import org.orbisgis.datamanagerapi.dataset.ISpatialTable;
+import org.orbisgis.datamanagerapi.dataset.ITable;
 
 /**
- * Implementation of the IDataSet interface. A table is a 2D (column/line) representation of data.
+ * Define the methods use to get the result of a SQL request.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2018)
+ * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface ITable extends IDataSet, ResultSet, IWhereBuilder {
+public interface IBuilderResult {
 
     /**
-     * Apply the given closure to each row.
+     * Apply the given closure on each row of the result of the SQL request.
      *
      * @param closure Closure to apply to each row.
      */
     void eachRow(Closure closure);
 
     /**
-     * Get the ResultSetMetaData of the DataSet.
+     * Convert the result of the SQL request into a ITable or ISpatialTable.
      *
-     * @return The metadata object.
+     * @param clazz New class of the result.
+     *
+     * @return The result wrapped into the given class.
      */
-    @Override
-    ResultSetMetaData getMetadata();
-    
-    /**
-     * Get all column names from the underlying table
-     * @return 
-     */
-    Collection<String> getColumnNames();
+    Object asType(Class clazz);
 
-    /**
-     * Save the table to a file
-     * @param filePath the path of the file to be saved
-     * @return true is the file has been saved
-     */
-    boolean save(String filePath);
+    ITable getTable();
 
-    /**
-     * Save the table to a file
-     * @param filePath the path of the file to be saved
-     * @param encoding Encoding property.
-     * @return true is the file has been saved
-     */
-    boolean save(String filePath, String encoding);
-    
+    ISpatialTable getSpatialTable();
 }

--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IConditionOrOptionBuilder.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IConditionOrOptionBuilder.java
@@ -34,57 +34,35 @@
  * or contact directly:
  * info_at_ orbisgis.org
  */
-package org.orbisgis.datamanagerapi.dataset;
-
-import groovy.lang.Closure;
-import org.orbisgis.datamanagerapi.dsl.IWhereBuilder;
-
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.util.Collection;
+package org.orbisgis.datamanagerapi.dsl;
 
 /**
- * Implementation of the IDataSet interface. A table is a 2D (column/line) representation of data.
+ * Interface defining methods for the SQL 'where' condition building. The request construction can be continued thanks to the
+ * IConditionOrOptionBuilder or its result can be get calling 'eachRow' to iterate on the resultSet or 'as ITable' to get the
+ * ITable object.
+ * The methods inherited from IOptionBuilder allow to set option returning an IOptionBuilder while
+ * IConditionOrOptionBuilder own methods allow to add where condition returning an IConditionOrOptionBuilder.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2018)
+ * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface ITable extends IDataSet, ResultSet, IWhereBuilder {
+public interface IConditionOrOptionBuilder extends IOptionBuilder {
 
     /**
-     * Apply the given closure to each row.
+     * Add a 'and' condition for the selection.
      *
-     * @param closure Closure to apply to each row.
-     */
-    void eachRow(Closure closure);
-
-    /**
-     * Get the ResultSetMetaData of the DataSet.
+     * @param condition Condition to add for for the selection.
      *
-     * @return The metadata object.
+     * @return ISqlBuilder instance to continue building.
      */
-    @Override
-    ResultSetMetaData getMetadata();
-    
-    /**
-     * Get all column names from the underlying table
-     * @return 
-     */
-    Collection<String> getColumnNames();
+    IConditionOrOptionBuilder and(String condition);
 
     /**
-     * Save the table to a file
-     * @param filePath the path of the file to be saved
-     * @return true is the file has been saved
+     * Add a 'or' condition for the selection.
+     *
+     * @param condition Condition to add for for the selection.
+     *
+     * @return ISqlBuilder instance to continue building.
      */
-    boolean save(String filePath);
-
-    /**
-     * Save the table to a file
-     * @param filePath the path of the file to be saved
-     * @param encoding Encoding property.
-     * @return true is the file has been saved
-     */
-    boolean save(String filePath, String encoding);
-    
+    IConditionOrOptionBuilder or(String condition);
 }

--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IFromBuilder.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IFromBuilder.java
@@ -34,57 +34,24 @@
  * or contact directly:
  * info_at_ orbisgis.org
  */
-package org.orbisgis.datamanagerapi.dataset;
-
-import groovy.lang.Closure;
-import org.orbisgis.datamanagerapi.dsl.IWhereBuilder;
-
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.util.Collection;
+package org.orbisgis.datamanagerapi.dsl;
 
 /**
- * Implementation of the IDataSet interface. A table is a 2D (column/line) representation of data.
+ * Interface defining methods for the SQL 'from' building. The request construction can be continued thanks to the
+ * IWhereBuilder or its result can be get calling 'eachRow' to iterate on the resultSet or 'as ITable' to get the
+ * ITable object
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2018)
+ * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface ITable extends IDataSet, ResultSet, IWhereBuilder {
+public interface IFromBuilder {
 
     /**
-     * Apply the given closure to each row.
+     * Indicates the table use for the selection.
      *
-     * @param closure Closure to apply to each row.
-     */
-    void eachRow(Closure closure);
-
-    /**
-     * Get the ResultSetMetaData of the DataSet.
+     * @param tables Array of the table use for the selection.
      *
-     * @return The metadata object.
+     * @return ISqlBuilder instance to continue building.
      */
-    @Override
-    ResultSetMetaData getMetadata();
-    
-    /**
-     * Get all column names from the underlying table
-     * @return 
-     */
-    Collection<String> getColumnNames();
-
-    /**
-     * Save the table to a file
-     * @param filePath the path of the file to be saved
-     * @return true is the file has been saved
-     */
-    boolean save(String filePath);
-
-    /**
-     * Save the table to a file
-     * @param filePath the path of the file to be saved
-     * @param encoding Encoding property.
-     * @return true is the file has been saved
-     */
-    boolean save(String filePath, String encoding);
-    
+    IWhereBuilder from(String... tables);
 }

--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IOptionBuilder.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IOptionBuilder.java
@@ -36,64 +36,19 @@
  */
 package org.orbisgis.datamanagerapi.dsl;
 
-import org.orbisgis.datamanagerapi.dataset.ITable;
-
 import java.util.Map;
 
 /**
- * Interface defining methods for the SQL request building (select, from ...).
+ * Interface defining methods for the SQL request option building (LIMIT, GROUP BY, ORDER BY, ...). The request
+ * construction can be continued thanks to the IOptionBuilder or its result can be get calling 'eachRow' to iterate on
+ * the resultSet or 'as ITable' to get the ITable object.
  *
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface ISqlBuilder {
+public interface IOptionBuilder extends IBuilderResult {
 
     enum Order{ASC, DESC}
-
-    /**
-     * Start point of the SQL request.
-     *
-     * @param fields Array of the fields to select.
-     *
-     * @return ISqlBuilder instance to continue building.
-     */
-    ISqlBuilder select(String... fields);
-
-    /**
-     * Indicates the table use for the selection.
-     *
-     * @param tables Array of the table use for the selection.
-     *
-     * @return ISqlBuilder instance to continue building.
-     */
-    ISqlBuilder from(String... tables);
-
-    /**
-     * Indicates the condition for the selection.
-     *
-     * @param condition Condition to use for for the selection.
-     *
-     * @return ISqlBuilder instance to continue building.
-     */
-    ISqlBuilder where(String condition);
-
-    /**
-     * Add a 'and' condition for the selection.
-     *
-     * @param condition Condition to add for for the selection.
-     *
-     * @return ISqlBuilder instance to continue building.
-     */
-    ISqlBuilder and(String condition);
-
-    /**
-     * Add a 'or' condition for the selection.
-     *
-     * @param condition Condition to add for for the selection.
-     *
-     * @return ISqlBuilder instance to continue building.
-     */
-    ISqlBuilder or(String condition);
 
     /**
      * Set the group by fields.
@@ -102,7 +57,7 @@ public interface ISqlBuilder {
      *
      * @return ISqlBuilder instance to continue building.
      */
-    ISqlBuilder groupBy(String... fields);
+    IOptionBuilder groupBy(String... fields);
 
     /**
      * Set the order by fields.
@@ -111,7 +66,7 @@ public interface ISqlBuilder {
      *
      * @return ISqlBuilder instance to continue building.
      */
-    ISqlBuilder orderBy(Map<String, Order> orderByMap);
+    IOptionBuilder orderBy(Map<String, Order> orderByMap);
 
     /**
      * Set the order by unique field.
@@ -121,7 +76,7 @@ public interface ISqlBuilder {
      *
      * @return ISqlBuilder instance to continue building.
      */
-    ISqlBuilder orderBy(String field, Order order);
+    IOptionBuilder orderBy(String field, Order order);
 
     /**
      * Set the ASC order by unique field.
@@ -130,7 +85,7 @@ public interface ISqlBuilder {
      *
      * @return ISqlBuilder instance to continue building.
      */
-    ISqlBuilder orderBy(String field);
+    IOptionBuilder orderBy(String field);
 
     /**
      * Set the limit of the request.
@@ -139,10 +94,5 @@ public interface ISqlBuilder {
      *
      * @return ISqlBuilder instance to continue building.
      */
-    ISqlBuilder limit(int limitCount);
-
-    /**
-     * Execute the query.
-     */
-    ITable execute();
+    IOptionBuilder limit(int limitCount);
 }

--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/ISelectBuilder.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/ISelectBuilder.java
@@ -34,57 +34,25 @@
  * or contact directly:
  * info_at_ orbisgis.org
  */
-package org.orbisgis.datamanagerapi.dataset;
 
-import groovy.lang.Closure;
-import org.orbisgis.datamanagerapi.dsl.IWhereBuilder;
+package org.orbisgis.datamanagerapi.dsl;
 
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.util.Collection;
 
 /**
- * Implementation of the IDataSet interface. A table is a 2D (column/line) representation of data.
+ * Interface defining methods for the SQL 'select' building. The request construction can be continued thanks to the
+ * IFromBuilder.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2018)
+ * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface ITable extends IDataSet, ResultSet, IWhereBuilder {
+public interface ISelectBuilder {
 
     /**
-     * Apply the given closure to each row.
+     * Start point of the SQL request.
      *
-     * @param closure Closure to apply to each row.
-     */
-    void eachRow(Closure closure);
-
-    /**
-     * Get the ResultSetMetaData of the DataSet.
+     * @param fields Array of the fields to select.
      *
-     * @return The metadata object.
+     * @return ISqlBuilder instance to continue building.
      */
-    @Override
-    ResultSetMetaData getMetadata();
-    
-    /**
-     * Get all column names from the underlying table
-     * @return 
-     */
-    Collection<String> getColumnNames();
-
-    /**
-     * Save the table to a file
-     * @param filePath the path of the file to be saved
-     * @return true is the file has been saved
-     */
-    boolean save(String filePath);
-
-    /**
-     * Save the table to a file
-     * @param filePath the path of the file to be saved
-     * @param encoding Encoding property.
-     * @return true is the file has been saved
-     */
-    boolean save(String filePath, String encoding);
-    
+    IFromBuilder select(String... fields);
 }

--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IWhereBuilder.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IWhereBuilder.java
@@ -34,57 +34,26 @@
  * or contact directly:
  * info_at_ orbisgis.org
  */
-package org.orbisgis.datamanagerapi.dataset;
-
-import groovy.lang.Closure;
-import org.orbisgis.datamanagerapi.dsl.IWhereBuilder;
-
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.util.Collection;
+package org.orbisgis.datamanagerapi.dsl;
 
 /**
- * Implementation of the IDataSet interface. A table is a 2D (column/line) representation of data.
+ * Interface defining methods for the SQL 'from' building. The request construction can be continued thanks to the
+ * IConditionOrOptionBuilder or its result can be get calling 'eachRow' to iterate on the resultSet or 'as ITable' to
+ * get the ITable object.
+ * As the IConditionOrOptionBuilder extends IOptionBuilder the result of the where method ca be
+ * used to add condition (using AND or OR) or to set options (Like LIMIT, GROUP BY, ...).
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2018)
+ * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface ITable extends IDataSet, ResultSet, IWhereBuilder {
+public interface IWhereBuilder {
 
     /**
-     * Apply the given closure to each row.
+     * Indicates the condition for the selection.
      *
-     * @param closure Closure to apply to each row.
-     */
-    void eachRow(Closure closure);
-
-    /**
-     * Get the ResultSetMetaData of the DataSet.
+     * @param condition Condition to use for for the selection.
      *
-     * @return The metadata object.
+     * @return ISqlBuilder instance to continue building.
      */
-    @Override
-    ResultSetMetaData getMetadata();
-    
-    /**
-     * Get all column names from the underlying table
-     * @return 
-     */
-    Collection<String> getColumnNames();
-
-    /**
-     * Save the table to a file
-     * @param filePath the path of the file to be saved
-     * @return true is the file has been saved
-     */
-    boolean save(String filePath);
-
-    /**
-     * Save the table to a file
-     * @param filePath the path of the file to be saved
-     * @param encoding Encoding property.
-     * @return true is the file has been saved
-     */
-    boolean save(String filePath, String encoding);
-    
+    IConditionOrOptionBuilder where(String condition);
 }

--- a/data-manager/src/main/java/org/orbisgis/datamanager/dsl/ConditionOrOptionBuilder.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/dsl/ConditionOrOptionBuilder.java
@@ -1,0 +1,101 @@
+/*
+ * Bundle DataManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * DataManager is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * DataManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * DataManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * DataManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datamanager.dsl;
+
+import org.orbisgis.datamanager.JdbcDataSource;
+import org.orbisgis.datamanagerapi.dataset.ISpatialTable;
+import org.orbisgis.datamanagerapi.dataset.ITable;
+import org.orbisgis.datamanagerapi.dsl.IConditionOrOptionBuilder;
+
+/**
+ * Implementation of IConditionOrOptionBuilder
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public class ConditionOrOptionBuilder extends OptionBuilder implements IConditionOrOptionBuilder {
+
+    private StringBuilder query;
+    private JdbcDataSource dataSource;
+
+    /**
+     * Main constructor.
+     *
+     * @param request    String request coming from the ISelectBuilder.
+     * @param dataSource JdbcDataSource where the request will be executed.
+     */
+    public ConditionOrOptionBuilder(String request, JdbcDataSource dataSource) {
+        super(request, dataSource);
+        query = new StringBuilder();
+        query.append(request).append(" ");
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public IConditionOrOptionBuilder and(String condition) {
+        query.append("AND ");
+        query.append(condition);
+        return new ConditionOrOptionBuilder(query.toString(), dataSource);
+    }
+
+    @Override
+    public IConditionOrOptionBuilder or(String condition) {
+        query.append("OR ");
+        query.append(condition);
+        return new ConditionOrOptionBuilder(query.toString(), dataSource);
+    }
+
+    @Override
+    protected JdbcDataSource getDataSource() {
+        return dataSource;
+    }
+
+    @Override
+    protected String getQuery() {
+        return query.toString();
+    }
+
+    @Override
+    public ITable getTable() {
+        return ((ITable)asType(ITable.class));
+    }
+
+    @Override
+    public ISpatialTable getSpatialTable() {
+        return ((ISpatialTable)asType(ISpatialTable.class));
+    }
+}

--- a/data-manager/src/main/java/org/orbisgis/datamanager/dsl/FromBuilder.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/dsl/FromBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Bundle DataManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * DataManager is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * DataManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * DataManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * DataManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datamanager.dsl;
+
+import org.orbisgis.datamanager.JdbcDataSource;
+import org.orbisgis.datamanagerapi.dsl.IFromBuilder;
+import org.orbisgis.datamanagerapi.dsl.IWhereBuilder;
+
+/**
+ * Implementation of IFromBuilder
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public class FromBuilder implements IFromBuilder {
+
+    private StringBuilder query;
+    private JdbcDataSource dataSource;
+
+    /**
+     * Main constructor.
+     *
+     * @param request String request coming from the ISelectBuilder.
+     * @param dataSource JdbcDataSource where the request will be executed.
+     */
+    public FromBuilder(String request, JdbcDataSource dataSource){
+        query = new StringBuilder();
+        query.append(request).append(" ");
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public IWhereBuilder from(String... tables) {
+        query.append("FROM ");
+        for(String table : tables){
+            query.append(table).append(", ");
+        }
+        query.deleteCharAt(query.length()-2);
+        return new WhereBuilder(query.toString(), dataSource);
+    }
+}

--- a/data-manager/src/main/java/org/orbisgis/datamanager/dsl/OptionBuilder.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/dsl/OptionBuilder.java
@@ -1,0 +1,124 @@
+/*
+ * Bundle DataManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * DataManager is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * DataManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * DataManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * DataManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datamanager.dsl;
+
+import org.orbisgis.datamanager.JdbcDataSource;
+import org.orbisgis.datamanagerapi.dataset.ISpatialTable;
+import org.orbisgis.datamanagerapi.dataset.ITable;
+import org.orbisgis.datamanagerapi.dsl.IOptionBuilder;
+
+import java.util.Map;
+
+/**
+ * Implementation of IOptionBuilder
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public class OptionBuilder extends BuilderResult implements IOptionBuilder {
+
+    private StringBuilder query;
+    private JdbcDataSource dataSource;
+
+    /**
+     * Main constructor.
+     *
+     * @param request    String request coming from the ISelectBuilder.
+     * @param dataSource JdbcDataSource where the request will be executed.
+     */
+    public OptionBuilder(String request, JdbcDataSource dataSource) {
+        query = new StringBuilder();
+        query.append(request).append(" ");
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public IOptionBuilder groupBy(String... fields) {
+        query.append("GROUP BY ");
+        for(String field : fields){
+            query.append(field).append(", ");
+        }
+        query.deleteCharAt(query.length()-2);
+        return new OptionBuilder(query.toString(), dataSource);
+    }
+
+    @Override
+    public IOptionBuilder orderBy(Map<String, Order> orderByMap) {
+        query.append("ORDER BY ");
+        orderByMap.forEach((key, value) -> query.append(key).append(" ").append(value.name()).append(", "));
+        query.deleteCharAt(query.length()-2);
+        return new OptionBuilder(query.toString(), dataSource);
+    }
+
+    @Override
+    public IOptionBuilder orderBy(String field, Order order) {
+        query.append("ORDER BY ").append(field).append(" ").append(order.name());
+        return new OptionBuilder(query.toString(), dataSource);
+    }
+
+    @Override
+    public IOptionBuilder orderBy(String field) {
+        query.append("ORDER BY ").append(field);
+        return new OptionBuilder(query.toString(), dataSource);
+    }
+
+    @Override
+    public IOptionBuilder limit(int limitCount) {
+        query.append("LIMIT ").append(limitCount);
+        return new OptionBuilder(query.toString(), dataSource);
+    }
+
+    @Override
+    protected JdbcDataSource getDataSource() {
+        return dataSource;
+    }
+
+    @Override
+    protected String getQuery() {
+        return query.toString();
+    }
+
+    @Override
+    public ITable getTable() {
+        return ((ITable)asType(ITable.class));
+    }
+
+    @Override
+    public ISpatialTable getSpatialTable() {
+        return ((ISpatialTable)asType(ISpatialTable.class));
+    }
+}

--- a/data-manager/src/main/java/org/orbisgis/datamanager/dsl/WhereBuilder.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/dsl/WhereBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * Bundle DataManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * DataManager is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * DataManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * DataManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * DataManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datamanager.dsl;
+
+import org.orbisgis.datamanager.JdbcDataSource;
+import org.orbisgis.datamanagerapi.dataset.ISpatialTable;
+import org.orbisgis.datamanagerapi.dataset.ITable;
+import org.orbisgis.datamanagerapi.dsl.IBuilderResult;
+import org.orbisgis.datamanagerapi.dsl.IConditionOrOptionBuilder;
+import org.orbisgis.datamanagerapi.dsl.IWhereBuilder;
+
+/**
+ * Implementation of IWhereBuilder
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public class WhereBuilder extends BuilderResult implements IWhereBuilder, IBuilderResult {
+
+    private StringBuilder query;
+    private JdbcDataSource dataSource;
+
+    /**
+     * Main constructor.
+     *
+     * @param request String request coming from the ISelectBuilder.
+     * @param dataSource JdbcDataSource where the request will be executed.
+     */
+    public WhereBuilder(String request, JdbcDataSource dataSource){
+        query = new StringBuilder();
+        query.append(request).append(" ");
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public IConditionOrOptionBuilder where(String condition) {
+        query.append("WHERE ");
+        query.append(condition);
+        return new ConditionOrOptionBuilder(query.toString(), dataSource);
+    }
+
+    @Override
+    protected JdbcDataSource getDataSource() {
+        return dataSource;
+    }
+
+    @Override
+    protected String getQuery() {
+        return query.toString();
+    }
+
+    @Override
+    public ITable getTable() {
+         return ((ITable)asType(ITable.class));
+    }
+
+    @Override
+    public ISpatialTable getSpatialTable() {
+        return ((ISpatialTable)asType(ISpatialTable.class));
+    }
+}

--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2GIS.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2GIS.java
@@ -178,7 +178,7 @@ public class H2GIS extends JdbcDataSource {
             LOGGER.error("Unable execute query.\n"+e.getLocalizedMessage());
             return null;
         }
-        return new H2gisTable(new TableLocation(tableName), rs, statement);
+        return new H2gisTable(new TableLocation(tableName), rs, statement, this);
     }
 
     @Override
@@ -197,7 +197,7 @@ public class H2GIS extends JdbcDataSource {
             LOGGER.error("Unable execute query.\n"+e.getLocalizedMessage());
             return null;
         }
-        return new H2gisSpatialTable(new TableLocation(tableName), rs, statement);
+        return new H2gisSpatialTable(new TableLocation(tableName), rs, statement, this);
     }
 
     @Override

--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisLinked.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisLinked.java
@@ -40,6 +40,7 @@ import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.URIUtilities;
 import org.h2gis.utilities.wrapper.ConnectionWrapper;
 import org.h2gis.utilities.wrapper.StatementWrapper;
+import org.orbisgis.datamanager.JdbcDataSource;
 import org.orbisgis.datamanagerapi.dataset.ISpatialTable;
 import org.orbisgis.datamanagerapi.dataset.ITable;
 import org.orbisgis.datamanagerapi.dataset.ITableWrapper;
@@ -59,6 +60,7 @@ public class H2gisLinked implements ITableWrapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(H2gisLinked.class);
     private String tableName;
     private ConnectionWrapper connectionWrapper;
+    private JdbcDataSource jdbcDataSource;
 
     /**
      * Create a dynamic link from a file
@@ -70,6 +72,7 @@ public class H2gisLinked implements ITableWrapper {
      */
     public H2gisLinked(String filePath, String tableName, boolean delete, H2GIS h2GIS) {
         create(filePath, tableName, delete, h2GIS);
+        jdbcDataSource = h2GIS;
     }
 
 
@@ -107,7 +110,7 @@ public class H2gisLinked implements ITableWrapper {
                 LOGGER.error("Unable execute query.\n"+e.getLocalizedMessage());
                 return null;
             }
-            return new H2gisTable(new TableLocation(tableName), rs, statement);
+            return new H2gisTable(new TableLocation(tableName), rs, statement, jdbcDataSource);
         }
         else if(clazz == ISpatialTable.class){
             StatementWrapper statement;
@@ -124,7 +127,7 @@ public class H2gisLinked implements ITableWrapper {
                 LOGGER.error("Unable execute query.\n"+e.getLocalizedMessage());
                 return null;
             }
-            return new H2gisSpatialTable(new TableLocation(tableName), rs, statement);
+            return new H2gisSpatialTable(new TableLocation(tableName), rs, statement, jdbcDataSource);
         }
         return null;
     }

--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisLoad.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisLoad.java
@@ -40,6 +40,7 @@ import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.URIUtilities;
 import org.h2gis.utilities.wrapper.ConnectionWrapper;
 import org.h2gis.utilities.wrapper.StatementWrapper;
+import org.orbisgis.datamanager.JdbcDataSource;
 import org.orbisgis.datamanager.io.IOMethods;
 import org.orbisgis.datamanagerapi.dataset.ISpatialTable;
 import org.orbisgis.datamanagerapi.dataset.ITable;
@@ -62,6 +63,7 @@ public class H2gisLoad implements ITableWrapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(H2gisLoad.class);
     private String tableName;
     private ConnectionWrapper connectionWrapper;
+    private JdbcDataSource jdbcDataSource;
 
     /**
      * Load a table to a H2GIS database from another database
@@ -74,6 +76,7 @@ public class H2gisLoad implements ITableWrapper {
      */
     public H2gisLoad(Map<String, String> properties, String inputTableName, String outputTableName, boolean delete, H2GIS h2GIS){
         create(properties, inputTableName, outputTableName, delete, h2GIS);
+        jdbcDataSource = h2GIS;
     }
 
     /**
@@ -91,6 +94,7 @@ public class H2gisLoad implements ITableWrapper {
         } else {
             LOGGER.error("Unsupported file characters");
         }
+        jdbcDataSource = h2GIS;
     }
 
     /**
@@ -104,6 +108,7 @@ public class H2gisLoad implements ITableWrapper {
      */
     public H2gisLoad(String filePath, String tableName, String encoding, boolean delete, H2GIS h2GIS) {
         create(filePath, tableName, encoding, delete, h2GIS);
+        jdbcDataSource = h2GIS;
     }
 
     @Override
@@ -129,7 +134,7 @@ public class H2gisLoad implements ITableWrapper {
                 LOGGER.error("Unable execute query.\n"+e.getLocalizedMessage());
                 return null;
             }
-            return new H2gisTable(new TableLocation(tableName), rs, statement);
+            return new H2gisTable(new TableLocation(tableName), rs, statement, jdbcDataSource);
         }
         else if(clazz == ISpatialTable.class){
             StatementWrapper statement;
@@ -146,7 +151,7 @@ public class H2gisLoad implements ITableWrapper {
                 LOGGER.error("Unable execute query.\n"+e.getLocalizedMessage());
                 return null;
             }
-            return new H2gisSpatialTable(new TableLocation(tableName), rs, statement);
+            return new H2gisSpatialTable(new TableLocation(tableName), rs, statement, jdbcDataSource);
         }
         return null;
     }

--- a/data-manager/src/main/java/org/orbisgis/datamanager/postgis/POSTGIS.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/postgis/POSTGIS.java
@@ -118,7 +118,7 @@ public class POSTGIS extends JdbcDataSource {
             LOGGER.error("Unable execute query.\n"+e.getLocalizedMessage());
             return null;
         }
-        return new PostgisTable(new TableLocation(tableName), rs, statement);
+        return new PostgisTable(new TableLocation(tableName), rs, statement, this);
     }
 
     @Override
@@ -137,7 +137,7 @@ public class POSTGIS extends JdbcDataSource {
             LOGGER.error("Unable execute query.\n"+e.getLocalizedMessage());
             return null;
         }
-        return new PostgisSpatialTable(new TableLocation(tableName), rs, statement);
+        return new PostgisSpatialTable(new TableLocation(tableName), rs, statement, this);
     }
 
     @Override

--- a/data-manager/src/main/java/org/orbisgis/datamanager/postgis/PostgisLoad.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/postgis/PostgisLoad.java
@@ -49,6 +49,7 @@ import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.URIUtilities;
 import org.h2gis.postgis_jts.ConnectionWrapper;
 import org.h2gis.postgis_jts.StatementWrapper;
+import org.orbisgis.datamanager.JdbcDataSource;
 import org.orbisgis.datamanager.io.IOMethods;
 import org.orbisgis.datamanagerapi.dataset.ISpatialTable;
 import org.orbisgis.datamanagerapi.dataset.ITable;
@@ -74,6 +75,7 @@ public class PostgisLoad implements ITableWrapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgisLoad.class);
     private String tableName;
     private ConnectionWrapper connectionWrapper;
+    private JdbcDataSource jdbcDataSource;
 
     /**
      * Load a table to a POSTGIS database from another database
@@ -86,6 +88,7 @@ public class PostgisLoad implements ITableWrapper {
      */
     public PostgisLoad(Map<String, String> properties, String inputTableName, String outputTableName, boolean delete, POSTGIS postgis){
         create(properties, inputTableName, outputTableName, delete, postgis);
+        jdbcDataSource = postgis;
     }
 
     /**
@@ -103,6 +106,7 @@ public class PostgisLoad implements ITableWrapper {
         } else {
             LOGGER.error("Unsupported file characters");
         }
+        jdbcDataSource = postgis;
     }
 
     /**
@@ -118,6 +122,7 @@ public class PostgisLoad implements ITableWrapper {
         } else {
             LOGGER.error("Unsupported file characters");
         }
+        jdbcDataSource = postgis;
     }
 
     @Override
@@ -143,7 +148,7 @@ public class PostgisLoad implements ITableWrapper {
                 LOGGER.error("Unable execute query.\n"+e.getLocalizedMessage());
                 return null;
             }
-            return new PostgisTable(new TableLocation(tableName), rs, statement);
+            return new PostgisTable(new TableLocation(tableName), rs, statement, jdbcDataSource);
         }
         else if(clazz == ISpatialTable.class){
             StatementWrapper statement;
@@ -160,7 +165,7 @@ public class PostgisLoad implements ITableWrapper {
                 LOGGER.error("Unable execute query.\n"+e.getLocalizedMessage());
                 return null;
             }
-            return new PostgisSpatialTable(new TableLocation(tableName), rs, statement);
+            return new PostgisSpatialTable(new TableLocation(tableName), rs, statement, jdbcDataSource);
         }
         return null;
     }


### PR DESCRIPTION
In order to respect the SQL request format, now the methods like `select`, `from`, `where`, ... can only be call in a specific order. So all the methods from `JdbcDataSource` has been moved into the classes of the package org.orbisgis.datamanager.dsl.

The `getSpatialTable` and  `getTable` from H2GIS and POSTGIS can be used to have a sub table using the SQL request building from  `where`.

Linked to #32 