### PR TITLE
Get methods

### DIFF
--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IJdbcTable.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IJdbcTable.java
@@ -114,6 +114,14 @@ public interface IJdbcTable extends ITable, GroovyObject {
                 if(args == null) {
                     m = this.getClass().getDeclaredMethod(getName);
                 }
+                else if(args instanceof Object[]){
+                    Object[] objects = (Object[])args;
+                    Class[] classes = new Class[objects.length];
+                    for(int i=0; i<objects.length; i++){
+                        classes[i] = objects[i].getClass();
+                    }
+                    m = this.getClass().getDeclaredMethod(getName, classes);
+                }
                 else {
                     m = this.getClass().getDeclaredMethod(getName, args.getClass());
                 }
@@ -127,6 +135,9 @@ public interface IJdbcTable extends ITable, GroovyObject {
         try {
             if(args == null) {
                 return m.invoke(this);
+            }
+            if(args instanceof Object[] && ((Object[])args).length == 1){
+                return m.invoke(this, ((Object[])args)[0]);
             }
             else {
                 return m.invoke(this, args);

--- a/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
+++ b/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
@@ -339,11 +339,11 @@ class GroovyH2GISTest {
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
         def file = new File('target/myscript.sql')
-        file.delete();
+        file.delete()
         file << 'CREATE TABLE super as SELECT * FROM $BINIOU;\n --COMMENTS HERE \nSELECT * FROM super;'
         h2GIS.executeScript("target/myscript.sql", [BINIOU:'h2gis']);
         def concat = ""
-        h2GIS.getSpatialTable "super" eachRow { row -> concat += "$row.id $row.the_geom $row.geometry\n" }
+        h2GIS.spatialTable "super" eachRow { row -> concat += "$row.id $row.the_geom $row.geometry\n" }
         assertEquals("1 POINT (10 10) POINT (10 10)\n2 POINT (1 1) POINT (1 1)\n", concat)
         println(concat)
     }
@@ -357,7 +357,7 @@ class GroovyH2GISTest {
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
         def file = new File('target/myscript.sql')
-        file.delete();
+        file.delete()
         file << 'CREATE TABLE super as SELECT * FROM h2gis;\n --COMMENTS HERE \nSELECT * FROM super;'
         h2GIS.executeScript("target/myscript.sql");
         def concat = ""
@@ -375,7 +375,7 @@ class GroovyH2GISTest {
                 INSERT INTO h2gis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
         """)
         def file = new File('target/myscript.sql')
-        file.delete();
+        file.delete()
         file << 'CREATE TABLE super as SELECT * FROM h2gis;\n --COMMENTS HERE \nSELECT * FROM super;'
         h2GIS.executeScript("target/myscript.sql", [:]);
         def concat = ""


### PR DESCRIPTION
Make all the get methods accessible under their short name in groovy for H2GIS and POSTGIS (i.e. spatialTable instead of getSpatialTable).
Linked to #34 