### PR TITLE
Separate orbisdata from framework parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <!-- The Basics -->
-    <parent>
-        <groupId>org.orbisgis</groupId>
-        <artifactId>framework</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
+    <groupId>org.orbisgis</groupId>
     <artifactId>orbisdata</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -85,6 +81,11 @@
                 <artifactId>jts-core</artifactId>
                 <version>1.15.1</version>
             </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.25</version>
+            </dependency>
             <!-- Test dependencies -->
             <dependency>
                 <groupId>ch.qos.logback</groupId>
@@ -137,6 +138,37 @@
                         </execution>
                     </executions>
                 </plugin>
+                <!-- Compilation -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+                <!-- Test -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.1</version>
+                    <configuration>
+                        <useSystemClassLoader>false</useSystemClassLoader>
+                    </configuration>
+                </plugin>
+                <!-- Generation of the OSGI bundle -->
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>4.1.0</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <instructions>
+                            <Bundle-Vendor>Lab-STICC - CNRS UMR 6285</Bundle-Vendor>
+                        </instructions>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -147,8 +179,8 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Separate orbisdata from framework to avoid further error with java version (8 vs 11).