### PR TITLE
Change orbisparent pom version to keep compatibility with Geoclimate.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.orbisgis</groupId>
         <artifactId>orbisparent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.1</version>
     </parent>
     <artifactId>orbisdata</artifactId>
     <version>1.0-SNAPSHOT</version>


### PR DESCRIPTION
Change orbisparent pom version to keep compatibility with Geoclimate.