### PR TITLE
Change the behaviour of Get(Spatial)Table

### DIFF
--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/datasource/IJdbcDataSource.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/datasource/IJdbcDataSource.java
@@ -68,7 +68,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
     void close();
 
     /**
-     * Return the {@link ITable} contained by the database with the given name.
+     * Return the {@link ITable} contained by the database with the given name. If the table contains a geometric
+     * field, return a ISpatialTable.
      *
      * @param tableName Name of the requested table.
      *
@@ -77,11 +78,13 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
     ITable getTable(String tableName);
 
     /**
-     * Return a {@link ISpatialTable} contained by the database with the given name.
+     * Return a {@link ISpatialTable} contained by the database with the given name. If the table doesn't contains a
+     * geometric field, return null;
      *
      * @param tableName Name of the requested table.
      *
-     * @return The {@link ISpatialTable} with the given name or null if no table is found.
+     * @return The {@link ISpatialTable} with the given name or null if no table is found or if the table doesn't
+     * contains a geometric field.
      */
     ISpatialTable getSpatialTable(String tableName);
 

--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2GIS.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2GIS.java
@@ -217,6 +217,14 @@ public class H2GIS extends JdbcDataSource {
             return null;
         }
         String query = String.format("SELECT * FROM %s", tableName);
+        try {
+            if(!SFSUtilities.getGeometryFields(getConnection(), new TableLocation(tableName)).isEmpty()) {
+                return new H2gisSpatialTable(new TableLocation(tableName), query, statement, this);
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Unable to check if table '" + tableName + "' contains geometric fields.\n" +
+                    e.getLocalizedMessage());
+        }
         return new H2gisTable(new TableLocation(tableName), query, statement, this);
     }
 
@@ -239,7 +247,16 @@ public class H2GIS extends JdbcDataSource {
             return null;
         }
         String query = String.format("SELECT * FROM %s", tableName);
-        return new H2gisSpatialTable(new TableLocation(tableName), query, statement, this);
+        try {
+            if(!SFSUtilities.getGeometryFields(getConnection(), new TableLocation(tableName)).isEmpty()) {
+                return new H2gisSpatialTable(new TableLocation(tableName), query, statement, this);
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Unable to check if table '" + tableName + "' contains geometric fields.\n" +
+                    e.getLocalizedMessage());
+        }
+        LOGGER.error("The table '" + tableName + "' is not a spatial table.");
+        return null;
     }
 
     @Override

--- a/data-manager/src/main/java/org/orbisgis/datamanager/postgis/POSTGIS.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/postgis/POSTGIS.java
@@ -154,6 +154,14 @@ public class POSTGIS extends JdbcDataSource {
             return null;
         }
         String query = String.format("SELECT * FROM %s", tableName);
+        try {
+            if(!SFSUtilities.getGeometryFields(getConnection(), new TableLocation(tableName)).isEmpty()) {
+                return new PostgisSpatialTable(new TableLocation(tableName), query, statement, this);
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Unable to check if table '" + tableName + "' contains geometric fields.\n" +
+                    e.getLocalizedMessage());
+        }
         return new PostgisTable(new TableLocation(tableName), query, statement, this);
     }
 
@@ -176,7 +184,16 @@ public class POSTGIS extends JdbcDataSource {
             return null;
         }
         String query = String.format("SELECT * FROM %s", tableName);
-        return new PostgisSpatialTable(new TableLocation(tableName), query, statement, this);
+        try {
+            if(!SFSUtilities.getGeometryFields(getConnection(), new TableLocation(tableName)).isEmpty()) {
+                return new PostgisSpatialTable(new TableLocation(tableName), query, statement, this);
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Unable to check if table '" + tableName + "' contains geometric fields.\n" +
+                    e.getLocalizedMessage());
+        }
+        LOGGER.error("The table '" + tableName + "' is not a spatial table.");
+        return null;
     }
 
     @Override

--- a/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
+++ b/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
@@ -262,7 +262,7 @@ class GroovyH2GISTest {
         h2GIS.save("h2gis","target/h2gis_imported.csv")
         h2GIS.load("target/h2gis_imported.csv")
         def concat = ""
-        h2GIS.getSpatialTable "h2gis_imported" eachRow { row ->
+        h2GIS.getTable "h2gis_imported" eachRow { row ->
             concat += "$row.id $row.the_geom\n" }
         assertEquals("1 POINT (10 10)\n2 POINT (1 1)\n", concat)
     }


### PR DESCRIPTION
Change the behaviour of Get(Spatial)Table:
- getTable return a ITable if no geometric field, a ISpatialTable otherwise
- getSpatial table return null if no geometric field.