### PR TITLE
Add JdbcColumn object

### DIFF
--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IColumn.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IColumn.java
@@ -1,0 +1,67 @@
+/*
+ * Bundle DataManager API is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * DataManager API  is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2019 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * DataManager API  is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * DataManager API  is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * DataManager API. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datamanagerapi.dataset;
+
+/**
+ * Column of a {@link IDataSet}.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public interface IColumn {
+
+    /**
+     * Return the name of the column.
+     *
+     * @return The name of the column.
+     */
+    String getName();
+
+    /**
+     * Return the sql type of the column.
+     *
+     * @return The sql type of the column.
+     */
+    String getType();
+
+    /**
+     * Return the number of the values inside the column.
+     *
+     * @return The number of the values inside the column.
+     */
+    long getSize();
+}

--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IJdbcColumn.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IJdbcColumn.java
@@ -1,0 +1,87 @@
+/*
+ * Bundle DataManager API is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * DataManager API  is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2019 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * DataManager API  is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * DataManager API  is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * DataManager API. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datamanagerapi.dataset;
+
+/**
+ * Column of a {@link IJdbcTable}.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public interface IJdbcColumn extends IColumn {
+
+    /**
+     * Return true if the column contains spatial data.
+     *
+     * @return True if the column contains spatial data.
+     */
+    boolean isSpatial();
+
+    /**
+     * Return true if the column has an index, false otherwise.
+     *
+     * @return True if the column has an index, false otherwise.
+     */
+    boolean isIndexed();
+
+    /**
+     * Return true if the column has a spatial index, false otherwise.
+     *
+     * @return True if the column has a spatial index, false otherwise.
+     */
+    boolean isSpatialIndexed();
+
+    /**
+     * Create an index of the column. If the column already has an index, no new index is created.
+     *
+     * @return True if an index has been created.
+     */
+    boolean createIndex();
+
+    /**
+     * Create an index of the column. If the column already has an index, no new index is created.
+     *
+     * @return True if an index has been created.
+     */
+    boolean createSpatialIndex();
+
+    /**
+     * Drop the index of the column if exists.
+     */
+    void dropIndex();
+
+}

--- a/data-manager/src/main/java/org/orbisgis/datamanager/JdbcColumn.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/JdbcColumn.java
@@ -1,0 +1,263 @@
+/*
+ * Bundle DataManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * DataManager is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * DataManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * DataManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * DataManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datamanager;
+
+import groovy.lang.GroovyObject;
+import groovy.lang.MetaClass;
+import groovy.lang.MissingMethodException;
+import org.codehaus.groovy.runtime.InvokerHelper;
+import org.h2gis.utilities.TableLocation;
+import org.orbisgis.datamanagerapi.dataset.DataBaseType;
+import org.orbisgis.datamanagerapi.dataset.IJdbcColumn;
+import org.orbisgis.datamanagerapi.datasource.IJdbcDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Contains the methods which are in common to all the {@link IJdbcColumn} subclasses.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public class JdbcColumn implements IJdbcColumn, GroovyObject {;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JdbcColumn.class);
+
+    /** MetaClass use for groovy methods/properties binding */
+    private MetaClass metaClass;
+    /** Name of the column. */
+    private String name;
+    /** Name of the table of the column. */
+    private TableLocation tableName;
+    /** {@link JdbcDataSource} of the column. */
+    private JdbcDataSource dataSource;
+    /** Indicates if the database is an H2 one. */
+    private boolean isH2;
+
+    /**
+     * Default constructor.
+     *
+     * @param name Name of the column.
+     * @param tableName Name of the table of the column.
+     * @param dataSource {@link IJdbcDataSource} of the column.
+     */
+    public JdbcColumn(String name, String tableName, JdbcDataSource dataSource){
+        this.isH2 = dataSource.getDataBaseType() == DataBaseType.H2GIS;
+        this.name = TableLocation.capsIdentifier(name, isH2);
+        this.tableName = TableLocation.parse(tableName, isH2);
+        this.dataSource = dataSource;
+        this.metaClass = InvokerHelper.getMetaClass(JdbcColumn.class);
+    }
+
+    @Override
+    public String getName(){
+        return name;
+    }
+
+    @Override
+    public String getType(){
+        try {
+            Map map = dataSource.firstRow("SELECT TYPE_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
+                    "WHERE INFORMATION_SCHEMA.COLUMNS.TABLE_NAME=? " +
+                    "AND INFORMATION_SCHEMA.COLUMNS.TABLE_SCHEMA=? " +
+                    "AND INFORMATION_SCHEMA.COLUMNS.COLUMN_NAME=?;",
+                    new Object[]{tableName.getTable(), tableName.getSchema("PUBLIC"), name});
+            if(map != null && map.containsKey("TYPE_NAME")){
+                return map.get("TYPE_NAME").toString();
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Unable to get the type of the column '"+name+"' in the table '"+tableName+"'.\n"+
+                    e.getLocalizedMessage());
+        }
+        return null;
+    }
+
+    @Override
+    public long getSize(){
+        try {
+            Map map = dataSource.firstRow("SELECT count("+TableLocation.quoteIdentifier(name, isH2)+
+                    ") FROM "+tableName.getTable());
+            if(map != null && !map.isEmpty() && map.values().toArray()[0] instanceof Long){
+                return (Long) map.values().toArray()[0];
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Unable to get the size of the column '"+name+"' in the table '"+tableName+"'.\n"+
+                    e.getLocalizedMessage());
+        }
+        return -1;
+    }
+
+    @Override
+    public boolean isSpatial(){
+        return "GEOMETRY".equals(getType());
+    }
+
+    @Override
+    public boolean isIndexed(){
+        try {
+            Map map = dataSource.firstRow("SELECT * FROM INFORMATION_SCHEMA.INDEXES " +
+                            "WHERE INFORMATION_SCHEMA.INDEXES.TABLE_NAME=? " +
+                            "AND INFORMATION_SCHEMA.INDEXES.TABLE_SCHEMA=? " +
+                            "AND INFORMATION_SCHEMA.INDEXES.COLUMN_NAME=?;",
+                    new Object[]{tableName.getTable(), tableName.getSchema("PUBLIC"), name});
+            return map != null;
+        } catch (SQLException e) {
+            LOGGER.error("Unable to get the type of the column '"+name+"' in the table '"+tableName+"'.\n"+
+                    e.getLocalizedMessage());
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isSpatialIndexed(){
+        try {
+            Map map = dataSource.firstRow("SELECT * FROM INFORMATION_SCHEMA.INDEXES " +
+                            "WHERE INFORMATION_SCHEMA.INDEXES.TABLE_NAME=? " +
+                            "AND INFORMATION_SCHEMA.INDEXES.TABLE_SCHEMA=? " +
+                            "AND INFORMATION_SCHEMA.INDEXES.COLUMN_NAME=?;",
+                    new Object[]{tableName.getTable(), tableName.getSchema("PUBLIC"), name});
+            return map != null && map.get("INDEX_TYPE_NAME").toString().contains("SPATIAL");
+        } catch (SQLException e) {
+            LOGGER.error("Unable to get the type of the column '"+name+"' in the table '"+tableName+"'.\n"+
+                    e.getLocalizedMessage());
+        }
+        return false;
+    }
+
+    @Override
+    public boolean createIndex(){
+        if(!isIndexed()) {
+            try {
+                dataSource.execute("CREATE INDEX ON "+tableName.toString(isH2)+" ("+
+                        TableLocation.quoteIdentifier(name, isH2)+")");
+                return true;
+            } catch (SQLException e) {
+                LOGGER.error("Unable to create an index on the column '" + name + "' in the table '" + tableName + "'.\n" +
+                        e.getLocalizedMessage());
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean createSpatialIndex(){
+        if(!isIndexed() && isSpatial()) {
+            try {
+                if(isH2){
+                    dataSource.execute("CREATE SPATIAL INDEX ON "+tableName.toString(isH2)+" ("+name+")");
+                }
+                else {
+                    dataSource.execute("CREATE INDEX ON "+tableName.toString(isH2)+" USING GIST ("+name+")");
+                }
+                return true;
+            } catch (SQLException e) {
+                LOGGER.error("Unable to create an index on the column '" + name + "' in the table '" + tableName + "'.\n" +
+                        e.getLocalizedMessage());
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void dropIndex(){
+        List<String> indexes = new ArrayList<>();
+        try {
+            List<? extends Map> list = dataSource.rows("SELECT INDEX_NAME FROM INFORMATION_SCHEMA.INDEXES " +
+                            "WHERE INFORMATION_SCHEMA.INDEXES.TABLE_NAME=? " +
+                            "AND INFORMATION_SCHEMA.INDEXES.TABLE_SCHEMA=? " +
+                            "AND INFORMATION_SCHEMA.INDEXES.COLUMN_NAME=?;",
+                    new Object[]{tableName.getTable(), tableName.getSchema("PUBLIC"), name});
+            for(Map map : list){
+                indexes.add(map.get("INDEX_NAME").toString());
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Unable to get the indexes of the column '"+name+"' in the table '"+tableName+"'.\n"+
+                    e.getLocalizedMessage());
+        }
+        for(String index : indexes) {
+            try {
+                dataSource.execute("DROP INDEX IF EXISTS " + index);
+            } catch (SQLException e) {
+                LOGGER.error("Unable to drop the index '"+index+"' on the column '" + name + "' in the table '" +
+                        tableName + "'.\n" + e.getLocalizedMessage());
+            }
+        }
+    }
+
+    @Override
+    public Object invokeMethod(String name, Object args) {
+        try {
+            return getMetaClass().invokeMethod(this, name, args);
+        } catch (MissingMethodException e) {
+            LOGGER.debug("Unable to find the '"+name+"' methods, trying with the getter.\n"+e.getLocalizedMessage());
+            try {
+                return getMetaClass()
+                    .invokeMethod(this, "get" + name.substring(0, 1).toUpperCase() + name.substring(1), args);
+            } catch (MissingMethodException e2) {
+                LOGGER.debug("Unable to find the '" + name + "' methods, trying with the is getter.\n" +
+                        e.getLocalizedMessage());
+            }
+            return getMetaClass()
+                            .invokeMethod(this, "is" + name.substring(0, 1).toUpperCase() + name.substring(1), args);
+        }
+    }
+
+    @Override
+    public Object getProperty(String propertyName) {
+        return getMetaClass().getProperty(this, propertyName);
+    }
+
+    @Override
+    public void setProperty(String propertyName, Object newValue) {
+        getMetaClass().setProperty(this, propertyName, newValue);
+    }
+
+    @Override
+    public MetaClass getMetaClass() {
+        return this.metaClass;
+    }
+
+    @Override
+    public void setMetaClass(MetaClass metaClass) {
+        this.metaClass = metaClass;
+    }
+}

--- a/data-manager/src/main/java/org/orbisgis/datamanager/JdbcTable.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/JdbcTable.java
@@ -321,10 +321,14 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
         if(propertyName.equals(META_PROPERTY)){
             return getMetadata();
         }
-        if(getColumnNames()!= null &&
-                (getColumnNames().contains(propertyName.toLowerCase()) || getColumnNames().contains(propertyName.toUpperCase()))
+        Collection<String> columns = getColumnNames();
+        if(columns!= null &&
+                (columns.contains(propertyName.toLowerCase()) || columns.contains(propertyName.toUpperCase()))
                 || "id".equals(propertyName)) {
             try {
+                if(isBeforeFirst()){
+                    return new JdbcColumn(propertyName, this.getName(), getJdbcDataSource());
+                }
                 return getObject(propertyName);
             } catch (SQLException e) {
                 LOGGER.debug("Unable to find the column '" + propertyName + "'.\n" + e.getLocalizedMessage());

--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2GIS.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2GIS.java
@@ -200,9 +200,9 @@ public class H2GIS extends JdbcDataSource {
 
     @Override
     public ITable getTable(String tableName) {
+        tableName = TableLocation.parse(tableName, getDataBaseType().equals(DataBaseType.H2GIS)).toString( getDataBaseType().equals(DataBaseType.H2GIS));
         try {
-            if(!JDBCUtilities.tableExists(connectionWrapper,
-                    TableLocation.parse(tableName, getDataBaseType().equals(DataBaseType.H2GIS)).getTable())){
+            if(!JDBCUtilities.tableExists(connectionWrapper,tableName)){
                 return null;
             }
         } catch (SQLException e) {
@@ -230,9 +230,9 @@ public class H2GIS extends JdbcDataSource {
 
     @Override
     public ISpatialTable getSpatialTable(String tableName) {
+        tableName = TableLocation.parse(tableName, getDataBaseType().equals(DataBaseType.H2GIS)).toString( getDataBaseType().equals(DataBaseType.H2GIS));
         try {
-            if(!JDBCUtilities.tableExists(connectionWrapper,
-                    TableLocation.parse(tableName, getDataBaseType().equals(DataBaseType.H2GIS)).getTable())){
+            if(!JDBCUtilities.tableExists(connectionWrapper, tableName)){
                 return null;
             }
         } catch (SQLException e) {

--- a/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
+++ b/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
@@ -546,4 +546,21 @@ class GroovyH2GISTest {
 
         assertNull h2GIS.getLocation() as Geometry
     }
+
+    @Test
+    void testColumn(){
+        def h2GIS = H2GIS.open('./target/orbisgis')
+        h2GIS.execute("""
+                DROP TABLE IF EXISTS orbisgis;
+                CREATE TABLE orbisgis (id int, the_geom point);
+                INSERT INTO orbisgis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
+        """)
+        assertEquals "INTEGER", h2GIS.getSpatialTable("orbisgis").id.type
+        assertEquals "ID", h2GIS.getSpatialTable("orbisgis").id.name
+        assertEquals 2, h2GIS.getSpatialTable("orbisgis").id.size
+        assertFalse h2GIS.getSpatialTable("orbisgis").the_geom.indexed
+        h2GIS.getSpatialTable("orbisgis").the_geom.createSpatialIndex()
+        assertTrue h2GIS.getSpatialTable("orbisgis").the_geom.indexed
+        assertTrue h2GIS.getSpatialTable("orbisgis").the_geom.spatialIndexed
+    }
 }

--- a/data-manager/src/test/java/org/orbisgis/datamanager/JdbcColumnTest.java
+++ b/data-manager/src/test/java/org/orbisgis/datamanager/JdbcColumnTest.java
@@ -1,0 +1,343 @@
+/*
+ * Bundle DataManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * DataManager is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * DataManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * DataManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * DataManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datamanager;
+
+import groovy.lang.MetaClass;
+import org.codehaus.groovy.runtime.InvokerHelper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.orbisgis.datamanager.h2gis.H2GIS;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class dedicated to {@link JdbcColumn} class.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public class JdbcColumnTest {
+
+    /** Default database name */
+    private static final String BASE_DATABASE = "./target/" + JdbcColumnTest.class.getSimpleName();
+    /** Database connection */
+    private static JdbcDataSource dataSource;
+
+    private static final String TABLE_NAME = "orbisgis";
+    private static final String TEMP_NAME = "tempTable";
+    private static final String LINKED_NAME = "linkedTable";
+
+    private static final String COL_THE_GEOM = "the_geom";
+    private static final String COL_THE_GEOM2 = "the_geom2";
+    private static final String COL_ID = "id";
+    private static final String COL_VALUE = "value";
+    private static final String COL_MEANING = "meaning";
+
+    private static final String COL_NO_COL = "COL_NO_COL";
+    private static final String COL_NO_TAB = "COL_NO_TAB";
+
+    /**
+     * Initialization of the database.
+     */
+    @BeforeAll
+    public static void init(){
+        dataSource = H2GIS.open(BASE_DATABASE);
+        try {
+            dataSource.execute("DROP TABLE IF EXISTS "+TABLE_NAME+","+LINKED_NAME+","+TEMP_NAME);
+        dataSource.execute("CREATE TABLE "+TABLE_NAME+" ("+COL_THE_GEOM+" GEOMETRY, "+COL_THE_GEOM2+" POINT," +
+                COL_ID+" INTEGER, "+COL_VALUE+" FLOAT, "+COL_MEANING+" VARCHAR)");
+        dataSource.execute("INSERT INTO "+TABLE_NAME+" VALUES ('POINT(0 0)', 'POINT(1 1)', 1, 2.3, 'Simple points')");
+        dataSource.execute("INSERT INTO "+TABLE_NAME+" VALUES ('POINT(0 1 2)', 'POINT(10 11 12)', 2, 0.568, '3D point')");
+        dataSource.execute("INSERT INTO "+TABLE_NAME+" VALUES (null, 'POINT(110 111 112)', 2, null, '3D point')");
+        } catch (SQLException e) {
+            fail(e);
+        }
+    }
+
+    /**
+     * Return a simple instantiation of a {@link JdbcColumn}.
+     *
+     * @param name Name of the column
+     *
+     * @return A simple instantiation of a {@link JdbcColumn}.
+     */
+    private JdbcColumn getColumn(String name){
+        if(COL_NO_TAB.equals(name)){
+            return new DummyJdbcColumn(name, name, dataSource);
+        }
+        return new DummyJdbcColumn(name, TABLE_NAME, dataSource);
+    }
+
+    /**
+     * Test the {@link JdbcColumn#getName()} method.
+     */
+    @Test
+    public void testGetName(){
+        assertEquals(COL_THE_GEOM.toUpperCase(), getColumn(COL_THE_GEOM).getName());
+        assertEquals(COL_THE_GEOM2.toUpperCase(), getColumn(COL_THE_GEOM2).getName());
+        assertEquals(COL_ID.toUpperCase(), getColumn(COL_ID).getName());
+        assertEquals(COL_VALUE.toUpperCase(), getColumn(COL_VALUE).getName());
+        assertEquals(COL_MEANING.toUpperCase(), getColumn(COL_MEANING).getName());
+        assertEquals(COL_NO_COL.toUpperCase(), getColumn(COL_NO_COL).getName());
+        assertEquals(COL_NO_TAB.toUpperCase(), getColumn(COL_NO_TAB).getName());
+    }
+
+    /**
+     * Test the {@link JdbcColumn#getType()} method.
+     */
+    @Test
+    public void testGetType(){
+        assertEquals("GEOMETRY", getColumn(COL_THE_GEOM).getType());
+        assertEquals("GEOMETRY", getColumn(COL_THE_GEOM2).getType());
+        assertEquals("INTEGER", getColumn(COL_ID).getType());
+        assertEquals("DOUBLE", getColumn(COL_VALUE).getType());
+        assertEquals("VARCHAR", getColumn(COL_MEANING).getType());
+        assertNull(getColumn(COL_NO_COL).getType());
+        assertNull(getColumn(COL_NO_TAB).getType());
+    }
+
+    /**
+     * Test the {@link JdbcColumn#getSize()} method.
+     */
+    @Test
+    public void testGetSize(){
+        assertEquals(2, getColumn(COL_THE_GEOM).getSize());
+        assertEquals(3, getColumn(COL_THE_GEOM2).getSize());
+        assertEquals(3, getColumn(COL_ID).getSize());
+        assertEquals(2, getColumn(COL_VALUE).getSize());
+        assertEquals(3, getColumn(COL_MEANING).getSize());
+        assertEquals(-1, getColumn(COL_NO_COL).getSize());
+        assertEquals(-1, getColumn(COL_NO_TAB).getSize());
+    }
+
+    /**
+     * Test the {@link JdbcColumn#isSpatial()} method.
+     */
+    @Test
+    public void testIsSpatial(){
+        assertTrue(getColumn(COL_THE_GEOM).isSpatial());
+        assertTrue(getColumn(COL_THE_GEOM2).isSpatial());
+        assertFalse(getColumn(COL_ID).isSpatial());
+        assertFalse(getColumn(COL_VALUE).isSpatial());
+        assertFalse(getColumn(COL_MEANING).isSpatial());
+        assertFalse(getColumn(COL_NO_COL).isSpatial());
+        assertFalse(getColumn(COL_NO_TAB).isSpatial());
+    }
+
+    /**
+     * Test the {@link JdbcColumn#isIndexed()}, {@link JdbcColumn#isSpatialIndexed()},
+     * {@link JdbcColumn#createIndex()}, {@link JdbcColumn#createSpatialIndex()}, {@link JdbcColumn#dropIndex()}
+     * methods.
+     */
+    @Test
+    public void testIndexes(){
+        //Test drop index
+        getColumn(COL_THE_GEOM).dropIndex();
+        getColumn(COL_THE_GEOM2).dropIndex();
+        getColumn(COL_ID).dropIndex();
+        getColumn(COL_VALUE).dropIndex();
+        getColumn(COL_MEANING).dropIndex();
+        getColumn(COL_NO_COL).dropIndex();
+        getColumn(COL_NO_TAB).dropIndex();
+
+        //Test no index
+        assertFalse(getColumn(COL_THE_GEOM).isIndexed());
+        assertFalse(getColumn(COL_THE_GEOM2).isIndexed());
+        assertFalse(getColumn(COL_ID).isIndexed());
+        assertFalse(getColumn(COL_VALUE).isIndexed());
+        assertFalse(getColumn(COL_MEANING).isIndexed());
+        assertFalse(getColumn(COL_NO_COL).isIndexed());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test no spatial index
+        assertFalse(getColumn(COL_THE_GEOM).isSpatialIndexed());
+        assertFalse(getColumn(COL_THE_GEOM2).isSpatialIndexed());
+        assertFalse(getColumn(COL_ID).isSpatialIndexed());
+        assertFalse(getColumn(COL_VALUE).isSpatialIndexed());
+        assertFalse(getColumn(COL_MEANING).isSpatialIndexed());
+        assertFalse(getColumn(COL_NO_COL).isSpatialIndexed());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test standard index creation
+        assertTrue(getColumn(COL_THE_GEOM).createIndex());
+        assertTrue(getColumn(COL_THE_GEOM2).createIndex());
+        assertTrue(getColumn(COL_ID).createIndex());
+        assertTrue(getColumn(COL_VALUE).createIndex());
+        assertTrue(getColumn(COL_MEANING).createIndex());
+        assertFalse(getColumn(COL_NO_COL).createIndex());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test no index re-creation
+        assertFalse(getColumn(COL_THE_GEOM).createIndex());
+        assertFalse(getColumn(COL_THE_GEOM2).createIndex());
+        assertFalse(getColumn(COL_ID).createIndex());
+        assertFalse(getColumn(COL_VALUE).createIndex());
+        assertFalse(getColumn(COL_MEANING).createIndex());
+        assertFalse(getColumn(COL_NO_COL).createIndex());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test index
+        assertTrue(getColumn(COL_THE_GEOM).isIndexed());
+        assertTrue(getColumn(COL_THE_GEOM2).isIndexed());
+        assertTrue(getColumn(COL_ID).isIndexed());
+        assertTrue(getColumn(COL_VALUE).isIndexed());
+        assertTrue(getColumn(COL_MEANING).isIndexed());
+        assertFalse(getColumn(COL_NO_COL).isIndexed());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test no spatial index
+        assertFalse(getColumn(COL_THE_GEOM).isSpatialIndexed());
+        assertFalse(getColumn(COL_THE_GEOM2).isSpatialIndexed());
+        assertFalse(getColumn(COL_ID).isSpatialIndexed());
+        assertFalse(getColumn(COL_VALUE).isSpatialIndexed());
+        assertFalse(getColumn(COL_MEANING).isSpatialIndexed());
+        assertFalse(getColumn(COL_NO_COL).isSpatialIndexed());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test drop index
+        getColumn(COL_THE_GEOM).dropIndex();
+        getColumn(COL_THE_GEOM2).dropIndex();
+        getColumn(COL_ID).dropIndex();
+        getColumn(COL_VALUE).dropIndex();
+        getColumn(COL_MEANING).dropIndex();
+        getColumn(COL_NO_COL).dropIndex();
+        getColumn(COL_NO_TAB).dropIndex();
+
+        //Test no index
+        assertFalse(getColumn(COL_THE_GEOM).isIndexed());
+        assertFalse(getColumn(COL_THE_GEOM2).isIndexed());
+        assertFalse(getColumn(COL_ID).isIndexed());
+        assertFalse(getColumn(COL_VALUE).isIndexed());
+        assertFalse(getColumn(COL_MEANING).isIndexed());
+        assertFalse(getColumn(COL_NO_COL).isIndexed());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test no spatial index
+        assertFalse(getColumn(COL_THE_GEOM).isSpatialIndexed());
+        assertFalse(getColumn(COL_THE_GEOM2).isSpatialIndexed());
+        assertFalse(getColumn(COL_ID).isSpatialIndexed());
+        assertFalse(getColumn(COL_VALUE).isSpatialIndexed());
+        assertFalse(getColumn(COL_MEANING).isSpatialIndexed());
+        assertFalse(getColumn(COL_NO_COL).isSpatialIndexed());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test spatial index  creation
+        assertTrue(getColumn(COL_THE_GEOM).createSpatialIndex());
+        assertTrue(getColumn(COL_THE_GEOM2).createSpatialIndex());
+        assertFalse(getColumn(COL_ID).createSpatialIndex());
+        assertFalse(getColumn(COL_VALUE).createSpatialIndex());
+        assertFalse(getColumn(COL_MEANING).createSpatialIndex());
+        assertFalse(getColumn(COL_NO_COL).createSpatialIndex());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test standard index
+        assertTrue(getColumn(COL_THE_GEOM).isIndexed());
+        assertTrue(getColumn(COL_THE_GEOM2).isIndexed());
+        assertFalse(getColumn(COL_ID).isIndexed());
+        assertFalse(getColumn(COL_VALUE).isIndexed());
+        assertFalse(getColumn(COL_MEANING).isIndexed());
+        assertFalse(getColumn(COL_NO_COL).isIndexed());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test spatial index
+        assertTrue(getColumn(COL_THE_GEOM).isSpatialIndexed());
+        assertTrue(getColumn(COL_THE_GEOM2).isSpatialIndexed());
+        assertFalse(getColumn(COL_ID).isSpatialIndexed());
+        assertFalse(getColumn(COL_VALUE).isSpatialIndexed());
+        assertFalse(getColumn(COL_MEANING).isSpatialIndexed());
+        assertFalse(getColumn(COL_NO_COL).isSpatialIndexed());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+
+        //Test no index re-creation
+        assertFalse(getColumn(COL_THE_GEOM).createIndex());
+        assertFalse(getColumn(COL_THE_GEOM2).createIndex());
+        assertTrue(getColumn(COL_ID).createIndex());
+        assertTrue(getColumn(COL_VALUE).createIndex());
+        assertTrue(getColumn(COL_MEANING).createIndex());
+        assertFalse(getColumn(COL_NO_COL).createIndex());
+        assertFalse(getColumn(COL_NO_TAB).isIndexed());
+    }
+
+    /**
+     * Test the {@link JdbcColumn#getMetaClass()} and {@link JdbcColumn#setMetaClass(MetaClass)} methods.
+     */
+    @Test
+    public void testMetaClass(){
+        JdbcColumn column = getColumn(COL_THE_GEOM);
+        assertEquals(InvokerHelper.getMetaClass(JdbcColumn.class), column.getMetaClass());
+        column.setMetaClass(InvokerHelper.getMetaClass(this.getClass()));
+        assertEquals(InvokerHelper.getMetaClass(this.getClass()), column.getMetaClass());
+    }
+
+    /**
+     * Test the {@link JdbcColumn#invokeMethod(String, Object)} method.
+     */
+    @Test
+    public void testInvokeMethod(){
+        JdbcColumn column = getColumn(COL_THE_GEOM);
+        column.invokeMethod("dropIndex", null);
+        assertTrue((Boolean)column.invokeMethod("createIndex", null));
+        assertTrue((Boolean)column.invokeMethod("indexed", null));
+        assertTrue((Boolean)column.invokeMethod("isIndexed", null));
+        assertEquals(COL_THE_GEOM.toUpperCase(), column.invokeMethod("getName", null));
+        assertEquals(COL_THE_GEOM.toUpperCase(), column.invokeMethod("name", null));
+    }
+
+    /**
+     * Test the {@link JdbcColumn#getProperty(String)}, {@link JdbcColumn#setProperty(String, Object)} method.
+     */
+    @Test
+    public void testProperties(){
+        JdbcColumn column = getColumn(COL_THE_GEOM);
+        column.createIndex();
+        assertTrue((Boolean)column.getProperty("indexed"));
+        assertEquals(COL_THE_GEOM.toUpperCase(), column.getProperty("name"));
+        column.setProperty("name", "toto");
+        assertEquals("toto", column.getProperty("name"));
+    }
+
+    /**
+     * Simple extension of the {@link JdbcColumn} class.
+     */
+    private class DummyJdbcColumn extends JdbcColumn{
+        private DummyJdbcColumn(String name, String tableName, JdbcDataSource dataSource){
+            super(name, tableName, dataSource);
+        }
+    }
+}


### PR DESCRIPTION
Add a JdbcColumn object wich can be requested from a JdbcTable. It contains some utility methods like index creation and property access. Linked to #108 

sample :
``` groovy
def h2GIS = H2GIS.open('./target/orbisgis')
h2GIS.execute("""
                DROP TABLE IF EXISTS orbisgis;
                CREATE TABLE orbisgis (id int, the_geom point);
                INSERT INTO orbisgis VALUES (1, 'POINT(10 10)'::GEOMETRY), (2, 'POINT(1 1)'::GEOMETRY);
        """)
def table = h2GIS.getSpatialTable("orbisgis")
assert "INTEGER" == table.id.type
assert "ID" == table.id.name
assert 2 == table.id.size
assert !table.the_geom.indexed
table.the_geom.createSpatialIndex()
assert table.the_geom.indexed
assert table.the_geom.spatialIndexed
```