### PR TITLE
Add cutom JdbcTable printing

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -10,7 +10,7 @@
         <artifactId>orbisdata</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <artifactId>data-manager</artifactId>
+    <artifactId>commons</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
@@ -29,56 +29,8 @@
             <artifactId>groovy</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-sql</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-templates</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>data-manager-api</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>commons</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>h2gis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>h2gis-utilities</artifactId>
-        </dependency>        
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.service.jdbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>postgis-jts</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>postgis-jts-osgi</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/commons/src/main/java/org/orbisgis/commons/printer/Ascii.java
+++ b/commons/src/main/java/org/orbisgis/commons/printer/Ascii.java
@@ -1,0 +1,153 @@
+/*
+ * Bundle Commons is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * Commons is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * Commons is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Commons is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Commons. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.commons.printer;
+
+/**
+ * Class for the printing of data in an Ascii style.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public class Ascii extends ICustomPrinter.CustomPrinter {
+
+    public enum CellPosition {CENTER, RIGHT, LEFT}
+
+    /** Width in character number of a single column. */
+    private int columnWidth;
+    /** Count of column. */
+    private int columnCount;
+    /** True of a table is currently drawn, false otherwise. */
+    private boolean isDrawingTable;
+    /** Current column index. */
+    private int columnIndex;
+
+    /**
+     * Main constructor.
+     *
+     * @param builder StringBuilder used for building the string
+     */
+    public Ascii(StringBuilder builder) {
+        super(builder);
+    }
+
+    /**
+     * Start the drawing of a table.
+     * @param columnWidth Width in character number of a single column.
+     * @param columnCount Count of column.
+     */
+    public void startTable(int columnWidth, int columnCount){
+        this.columnCount = columnCount;
+        this.columnWidth = columnWidth;
+        this.columnIndex = 0;
+        this.isDrawingTable = true;
+    }
+
+    public void endTable(){
+        this.columnCount = -1;
+        this.columnWidth = -1;
+        this.columnIndex = -1;
+        this.isDrawingTable = false;
+    }
+
+    /**
+     * Append a line separator to the builder.
+     */
+    public void appendTableLineSeparator(){
+        if(isDrawingTable) {
+            builder.append("+");
+            for (int i = 0; i < columnCount; i++) {
+                for (int j = 0; j < columnWidth - 1; j++) {
+                    builder.append("-");
+                }
+                builder.append("+");
+            }
+            builder.append("\n");
+        }
+    }
+
+    /**
+     * Add a single value to the table. Linebreak are automatically generated once the column count is reached.
+     *
+     * @param value Value to add to the table.
+     */
+    public void appendTableValue(Object value){
+        appendTableValue(value, CellPosition.LEFT);
+    }
+
+    /**
+     * Add a single value to the table. Linebreak are automatically generated once the column count is reached.
+     *
+     * @param value Value to add to the table.
+     */
+    public void appendTableValue(Object value, CellPosition position){
+        if(isDrawingTable){
+            builder.append("|");
+            String cut = value == null ? "null" : value.toString();
+            if (cut.length() > columnWidth - 1) {
+                cut = cut.substring(0, columnWidth - 4) + "...";
+            }
+            switch(position){
+                case LEFT:
+                    builder.append(cut);
+                    for (int i = 0; i < (columnWidth - 1 - cut.length()); i++) {
+                        builder.append(" ");
+                    }
+                    break;
+                case RIGHT:
+                    for (int i = 0; i < (columnWidth - 1 - cut.length()); i++) {
+                        builder.append(" ");
+                    }
+                    builder.append(cut);
+                    break;
+                case CENTER:
+                    for (int i = 0; i < (columnWidth - 1 - cut.length())/2; i++) {
+                        builder.append(" ");
+                    }
+                    builder.append(cut);
+                    for (int i = 0; i < (columnWidth - 1 - cut.length()) - (columnWidth - 1 - cut.length())/2; i++) {
+                        builder.append(" ");
+                    }
+            }
+            columnIndex ++;
+            if(columnIndex == columnCount){
+                columnIndex = 0;
+                builder.append("|");
+                builder.append("\n");
+            }
+        }
+    }
+}

--- a/commons/src/main/java/org/orbisgis/commons/printer/Ascii.java
+++ b/commons/src/main/java/org/orbisgis/commons/printer/Ascii.java
@@ -42,18 +42,7 @@ package org.orbisgis.commons.printer;
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)
  */
-public class Ascii extends ICustomPrinter.CustomPrinter {
-
-    public enum CellPosition {CENTER, RIGHT, LEFT}
-
-    /** Width in character number of a single column. */
-    private int columnWidth;
-    /** Count of column. */
-    private int columnCount;
-    /** True of a table is currently drawn, false otherwise. */
-    private boolean isDrawingTable;
-    /** Current column index. */
-    private int columnIndex;
+public class Ascii extends CustomPrinter {
 
     /**
      * Main constructor.
@@ -64,28 +53,7 @@ public class Ascii extends ICustomPrinter.CustomPrinter {
         super(builder);
     }
 
-    /**
-     * Start the drawing of a table.
-     * @param columnWidth Width in character number of a single column.
-     * @param columnCount Count of column.
-     */
-    public void startTable(int columnWidth, int columnCount){
-        this.columnCount = columnCount;
-        this.columnWidth = columnWidth;
-        this.columnIndex = 0;
-        this.isDrawingTable = true;
-    }
-
-    public void endTable(){
-        this.columnCount = -1;
-        this.columnWidth = -1;
-        this.columnIndex = -1;
-        this.isDrawingTable = false;
-    }
-
-    /**
-     * Append a line separator to the builder.
-     */
+    @Override
     public void appendTableLineSeparator(){
         if(isDrawingTable) {
             builder.append("+");
@@ -99,24 +67,11 @@ public class Ascii extends ICustomPrinter.CustomPrinter {
         }
     }
 
-    /**
-     * Add a single value to the table. Linebreak are automatically generated once the column count is reached.
-     *
-     * @param value Value to add to the table.
-     */
-    public void appendTableValue(Object value){
-        appendTableValue(value, CellPosition.LEFT);
-    }
-
-    /**
-     * Add a single value to the table. Linebreak are automatically generated once the column count is reached.
-     *
-     * @param value Value to add to the table.
-     */
-    public void appendTableValue(Object value, CellPosition position){
+    @Override
+    public void appendTableValue(Object value, ICustomPrinter.CellPosition position){
         if(isDrawingTable){
             builder.append("|");
-            String cut = value == null ? "null" : value.toString();
+            String cut = value == null ? "" : value.toString();
             if (cut.length() > columnWidth - 1) {
                 cut = cut.substring(0, columnWidth - 4) + "...";
             }
@@ -148,6 +103,38 @@ public class Ascii extends ICustomPrinter.CustomPrinter {
                 builder.append("|");
                 builder.append("\n");
             }
+        }
+    }
+
+    @Override
+    public void appendTableHeaderValue(Object value, ICustomPrinter.CellPosition position){
+        this.appendTableValue(value, position);
+    }
+
+    @Override
+    public void appendTableTitle(Object value){
+        if(isDrawingTable){
+            builder.append("+");
+            for (int j = 0; j < columnWidth - 1; j++) {
+                builder.append("-");
+            }
+            builder.append("+");
+            builder.append("\n");
+
+            builder.append("|");
+            String cut = value == null ? "" : value.toString();
+            if (cut.length() > columnWidth - 1) {
+                cut = cut.substring(0, columnWidth - 4) + "...";
+            }
+            for (int i = 0; i < (columnWidth - 1 - cut.length())/2; i++) {
+                builder.append(" ");
+            }
+            builder.append(cut);
+            for (int i = 0; i < (columnWidth - 1 - cut.length()) - (columnWidth - 1 - cut.length())/2; i++) {
+                builder.append(" ");
+            }
+            builder.append("|");
+            builder.append("\n");
         }
     }
 }

--- a/commons/src/main/java/org/orbisgis/commons/printer/CustomPrinter.java
+++ b/commons/src/main/java/org/orbisgis/commons/printer/CustomPrinter.java
@@ -37,59 +37,56 @@
 package org.orbisgis.commons.printer;
 
 /**
- * Interface used for the customisation of the printing of Java Objects.
+ * Root class for the custom printers.
  *
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface ICustomPrinter {
+public abstract class CustomPrinter implements ICustomPrinter {
 
-    /** Cell positions.*/
-    enum CellPosition {CENTER, RIGHT, LEFT}
+    /** {@link StringBuilder} used for the string building. */
+    protected StringBuilder builder;
+    /** Width in character number of a single column. */
+    protected int columnWidth;
+    /** Count of column. */
+    protected int columnCount;
+    /** True of a table is currently drawn, false otherwise. */
+    protected boolean isDrawingTable;
+    /** Current column index. */
+    protected int columnIndex;
 
     /**
-     * Start the drawing of a table.
+     * Main constructor.
      *
-     * @param columnWidth Width in character number of a single column.
-     * @param columnCount Count of column.
+     * @param builder {@link StringBuilder} used for the string building.
      */
-    void startTable(int columnWidth, int columnCount);
+    public CustomPrinter(StringBuilder builder){
+        this.builder = builder;
+    }
 
-    /**
-     * End the table drawing.
-     */
-    void endTable();
+    @Override
+    public String toString(){
+        return builder.toString();
+    }
 
-    /**
-     * Append a line separator to the builder.
-     */
-    void appendTableLineSeparator();
+    @Override
+    public void startTable(int columnWidth, int columnCount){
+        this.columnCount = columnCount;
+        this.columnWidth = columnWidth;
+        this.columnIndex = 0;
+        this.isDrawingTable = true;
+    }
 
-    /**
-     * Add a single value to the table. Linebreak are automatically generated once the column count is reached.
-     *
-     * @param value Value to add to the table.
-     */
-    void appendTableValue(Object value);
+    @Override
+    public void endTable(){
+        this.columnCount = -1;
+        this.columnWidth = -1;
+        this.columnIndex = -1;
+        this.isDrawingTable = false;
+    }
 
-    /**
-     * Add a single value to the table. Linebreak are automatically generated once the column count is reached.
-     *
-     * @param value Value to add to the table.
-     */
-    void appendTableValue(Object value, CellPosition position);
-
-    /**
-     * Add a header value to the table. Linebreak are automatically generated once the column count is reached.
-     *
-     * @param value Header value to add to the table.
-     */
-    void appendTableHeaderValue(Object value, CellPosition position);
-
-    /**
-     * Add a title to the table.
-     *
-     * @param title Title to add to the table.
-     */
-    void appendTableTitle(Object title);
+    @Override
+    public void appendTableValue(Object value){
+        appendTableValue(value, ICustomPrinter.CellPosition.LEFT);
+    }
 }

--- a/commons/src/main/java/org/orbisgis/commons/printer/CustomPrinter.java
+++ b/commons/src/main/java/org/orbisgis/commons/printer/CustomPrinter.java
@@ -1,0 +1,59 @@
+/*
+ * Bundle Commons is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * Commons is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * Commons is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Commons is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Commons. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.commons.printer;
+
+/**
+ * Interface used for the customisation of the printing of Java Objects.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public interface CustomPrinter {
+    /**
+     * Interface for the printing of data in an ascii style
+     */
+    class Ascii{
+        private StringBuilder builder;
+        public Ascii(StringBuilder builder){
+            this.builder = builder;
+        }
+        @Override
+        public String toString(){
+            return builder.toString();
+        }
+    }
+}

--- a/commons/src/main/java/org/orbisgis/commons/printer/Html.java
+++ b/commons/src/main/java/org/orbisgis/commons/printer/Html.java
@@ -42,7 +42,7 @@ package org.orbisgis.commons.printer;
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)
  */
-public class Html extends ICustomPrinter.CustomPrinter {
+public class Html extends CustomPrinter {
 
     /**
      * Main constructor.
@@ -51,5 +51,73 @@ public class Html extends ICustomPrinter.CustomPrinter {
      */
     public Html(StringBuilder builder) {
         super(builder);
+    }
+
+    @Override
+    public void appendTableLineSeparator() {
+        if(isDrawingTable){
+            builder.append("<tr></tr>\n");
+        }
+    }
+
+    @Override
+    public void startTable(int columnWidth, int columnCount){
+        builder.append("<table>\n");
+        super.startTable(columnWidth, columnCount);
+    }
+
+    @Override
+    public void endTable(){
+        super.endTable();
+        builder.append("</table>\n");
+    }
+
+    @Override
+    public void appendTableValue(Object value, CellPosition position) {
+        if (isDrawingTable) {
+            if(columnIndex == 0){
+                builder.append("<tr>\n");
+            }
+            builder.append("<td align=\"");
+            builder.append(position);
+            builder.append("\">");
+            builder.append(value);
+            builder.append("</td>");
+            builder.append("\n");
+            columnIndex ++;
+            if(columnIndex == columnCount){
+                builder.append("</tr>\n");
+                columnIndex = 0;
+            }
+        }
+    }
+
+    @Override
+    public void appendTableHeaderValue(Object value, CellPosition position) {
+        if (isDrawingTable) {
+            if(columnIndex == 0){
+                builder.append("<tr>\n");
+            }
+            builder.append("<th align=\"");
+            builder.append(position);
+            builder.append("\">");
+            builder.append(value);
+            builder.append("</th>");
+            builder.append("\n");
+            columnIndex ++;
+            if(columnIndex == columnCount){
+                builder.append("</tr>\n");
+                columnIndex = 0;
+            }
+        }
+    }
+
+    @Override
+    public void appendTableTitle(Object title) {
+        if(isDrawingTable) {
+            builder.append("<caption>");
+            builder.append(title);
+            builder.append("</caption>\n");
+        }
     }
 }

--- a/commons/src/main/java/org/orbisgis/commons/printer/Html.java
+++ b/commons/src/main/java/org/orbisgis/commons/printer/Html.java
@@ -37,23 +37,19 @@
 package org.orbisgis.commons.printer;
 
 /**
- * Interface used for the customisation of the printing of Java Objects.
+ * Class for the printing of data in an Html style.
  *
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface CustomPrinter {
+public class Html extends ICustomPrinter.CustomPrinter {
+
     /**
-     * Interface for the printing of data in an ascii style
+     * Main constructor.
+     *
+     * @param builder StringBuilder used for building the string
      */
-    class Ascii{
-        private StringBuilder builder;
-        public Ascii(StringBuilder builder){
-            this.builder = builder;
-        }
-        @Override
-        public String toString(){
-            return builder.toString();
-        }
+    public Html(StringBuilder builder) {
+        super(builder);
     }
 }

--- a/commons/src/main/java/org/orbisgis/commons/printer/ICustomPrinter.java
+++ b/commons/src/main/java/org/orbisgis/commons/printer/ICustomPrinter.java
@@ -1,0 +1,60 @@
+/*
+ * Bundle Commons is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * Commons is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * Commons is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Commons is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Commons. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.commons.printer;
+
+/**
+ * Interface used for the customisation of the printing of Java Objects.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public interface ICustomPrinter {
+
+    /**
+     * Root class for the custom printers.
+     */
+    abstract class CustomPrinter {
+        protected StringBuilder builder;
+        public CustomPrinter(StringBuilder builder){
+            this.builder = builder;
+        }
+        @Override
+        public String toString(){
+            return builder.toString();
+        }
+    }
+}

--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IDataSet.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IDataSet.java
@@ -65,4 +65,13 @@ public interface IDataSet extends Iterable<Object> {
      * @return The metadata object.
      */
     Object getMetadata();
+
+    /**
+     * Convert the current object into another with the given class.
+     *
+     * @param clazz New class of the result.
+     *
+     * @return The current object into an other class.
+     */
+    Object asType(Class clazz);
 }

--- a/data-manager-api/src/test/java/org/orbisgis/datamanagerapi/dataset/ITableTest.java
+++ b/data-manager-api/src/test/java/org/orbisgis/datamanagerapi/dataset/ITableTest.java
@@ -292,6 +292,7 @@ public class ITableTest {
         @Override public String getLocation() {return null;}
         @Override public String getName() {return null;}
         @Override public Object getMetadata() {return null;}
+        @Override public Object asType(Class clazz) {return null;}
         @Override public Iterator<Object> iterator() {return new ResultSetIterator();}
     }
 }

--- a/data-manager/src/main/java/org/orbisgis/datamanager/dsl/BuilderResult.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/dsl/BuilderResult.java
@@ -40,6 +40,7 @@ import groovy.lang.Closure;
 import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.wrapper.StatementWrapper;
 import org.orbisgis.commons.printer.Ascii;
+import org.orbisgis.commons.printer.ICustomPrinter;
 import org.orbisgis.datamanager.JdbcDataSource;
 import org.orbisgis.datamanager.h2gis.H2gisSpatialTable;
 import org.orbisgis.datamanager.h2gis.H2gisTable;
@@ -86,7 +87,7 @@ public abstract class BuilderResult implements IBuilderResult {
 
     @Override
     public Object asType(Class clazz) {
-        if(clazz.equals(Ascii.class)){
+        if(ICustomPrinter.class.isAssignableFrom(clazz)){
             return this.getTable().asType(clazz);
         }
         Statement statement;

--- a/data-manager/src/main/java/org/orbisgis/datamanager/dsl/BuilderResult.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/dsl/BuilderResult.java
@@ -39,7 +39,9 @@ package org.orbisgis.datamanager.dsl;
 import groovy.lang.Closure;
 import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.wrapper.StatementWrapper;
+import org.orbisgis.commons.printer.CustomPrinter;
 import org.orbisgis.datamanager.JdbcDataSource;
+import org.orbisgis.datamanager.JdbcTable;
 import org.orbisgis.datamanager.h2gis.H2gisSpatialTable;
 import org.orbisgis.datamanager.h2gis.H2gisTable;
 import org.orbisgis.datamanager.postgis.PostgisSpatialTable;
@@ -85,6 +87,9 @@ public abstract class BuilderResult implements IBuilderResult {
 
     @Override
     public Object asType(Class clazz) {
+        if(clazz.equals(CustomPrinter.Ascii.class)){
+            return this.getTable().asType(clazz);
+        }
         Statement statement;
         try {
             statement = getDataSource().getConnection()

--- a/data-manager/src/main/java/org/orbisgis/datamanager/dsl/BuilderResult.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/dsl/BuilderResult.java
@@ -39,9 +39,8 @@ package org.orbisgis.datamanager.dsl;
 import groovy.lang.Closure;
 import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.wrapper.StatementWrapper;
-import org.orbisgis.commons.printer.CustomPrinter;
+import org.orbisgis.commons.printer.Ascii;
 import org.orbisgis.datamanager.JdbcDataSource;
-import org.orbisgis.datamanager.JdbcTable;
 import org.orbisgis.datamanager.h2gis.H2gisSpatialTable;
 import org.orbisgis.datamanager.h2gis.H2gisTable;
 import org.orbisgis.datamanager.postgis.PostgisSpatialTable;
@@ -87,7 +86,7 @@ public abstract class BuilderResult implements IBuilderResult {
 
     @Override
     public Object asType(Class clazz) {
-        if(clazz.equals(CustomPrinter.Ascii.class)){
+        if(clazz.equals(Ascii.class)){
             return this.getTable().asType(clazz);
         }
         Statement statement;
@@ -98,7 +97,7 @@ public abstract class BuilderResult implements IBuilderResult {
             LOGGER.error("Unable to create the StatementWrapper.\n" + e.getLocalizedMessage());
             return null;
         }
-        String name = "TABLE_"+ UUID.randomUUID().toString();
+        String name = "SQL_QUERY_RESULT";
         switch(getDataSource().getDataBaseType()) {
             case H2GIS:
                 if(!(statement instanceof StatementWrapper)){

--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisSpatialTable.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisSpatialTable.java
@@ -111,7 +111,7 @@ public class H2gisSpatialTable extends JdbcSpatialTable {
             return new H2gisSpatialTable(getTableLocation(), getBaseQuery(), (StatementWrapper)getStatement(),
                     getJdbcDataSource());
         } else {
-            return null;
+            return super.asType(clazz);
         }
     }
 }

--- a/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisTable.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/h2gis/H2gisTable.java
@@ -109,7 +109,7 @@ public class H2gisTable extends JdbcTable {
             return new H2gisSpatialTable(getTableLocation(), getBaseQuery(), (StatementWrapper)getStatement(),
                     getJdbcDataSource());
         } else {
-            return null;
+            return super.asType(clazz);
         }
     }
 }

--- a/data-manager/src/main/java/org/orbisgis/datamanager/postgis/PostgisSpatialTable.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/postgis/PostgisSpatialTable.java
@@ -109,7 +109,7 @@ public class PostgisSpatialTable extends JdbcSpatialTable {
             return new PostgisSpatialTable(getTableLocation(), getBaseQuery(), (StatementWrapper)getStatement(),
                     getJdbcDataSource());
         } else {
-            return null;
+            return super.asType(clazz);
         }
     }
 }

--- a/data-manager/src/main/java/org/orbisgis/datamanager/postgis/PostgisTable.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/postgis/PostgisTable.java
@@ -109,7 +109,7 @@ public class PostgisTable extends JdbcTable {
             return new PostgisSpatialTable(getTableLocation(), getBaseQuery(), (StatementWrapper)getStatement(),
                     getJdbcDataSource());
         } else {
-            return null;
+            return super.asType(clazz);
         }
     }
 }

--- a/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
+++ b/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
@@ -39,7 +39,7 @@ package org.orbisgis.datamanager
 import org.junit.jupiter.api.Test
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.Point
-import org.orbisgis.commons.printer.CustomPrinter
+import org.orbisgis.commons.printer.Ascii
 import org.orbisgis.datamanager.h2gis.H2GIS
 import org.orbisgis.datamanagerapi.dataset.ISpatialTable
 import org.orbisgis.datamanagerapi.dataset.ITable
@@ -523,7 +523,7 @@ class GroovyH2GISTest {
         assertNull h2GIS.load(osmFile, "OSM")
         assertNull h2GIS.load(osmFile, "OSM", true)
 
-        println h2GIS.getTable("INFORMATION_SCHEMA.COLUMNS") as CustomPrinter.Ascii
+        println h2GIS.getTable("INFORMATION_SCHEMA.COLUMNS") as Ascii
 
         h2GIS.eachRow "SELECT count(TABLE_NAME) as nb FROM INFORMATION_SCHEMA.TABLES where TABLE_NAME LIKE 'OSM%'",
                 { row ->
@@ -577,19 +577,23 @@ class GroovyH2GISTest {
                 (2, 'POINT(1 1)'::GEOMETRY, 'another string');
         """)
         assertEquals(
+                "+-------------------+\n" +
+                "|     ORBISGIS      |\n" +
                 "+-------------------+-------------------+-------------------+\n" +
-                        "|        ID         |     THE_GEOM      |VERY_LONG_TITLE_...|\n" +
-                        "+-------------------+-------------------+-------------------+\n" +
-                        "|1                  |POINT (10 10)      |just a string a ...|\n" +
-                        "|2                  |POINT (1 1)        |another string     |\n" +
-                        "+-------------------+-------------------+-------------------+\n",
-                (h2GIS.getSpatialTable("orbisgis") as CustomPrinter.Ascii).toString())
+                "|        ID         |     THE_GEOM      |VERY_LONG_TITLE_...|\n" +
+                "+-------------------+-------------------+-------------------+\n" +
+                "|                  1|POINT (10 10)      |just a string a ...|\n" +
+                "|                  2|POINT (1 1)        |another string     |\n" +
+                "+-------------------+-------------------+-------------------+\n",
+                (h2GIS.getSpatialTable("orbisgis") as Ascii).toString())
         assertEquals(
+                "+-------------------+\n" +
+                "| SQL_QUERY_RESULT  |\n" +
                 "+-------------------+-------------------+-------------------+\n" +
-                        "|        ID         |     THE_GEOM      |VERY_LONG_TITLE_...|\n" +
-                        "+-------------------+-------------------+-------------------+\n" +
-                        "|1                  |POINT (10 10)      |just a string a ...|\n" +
-                        "+-------------------+-------------------+-------------------+\n",
-                (h2GIS.getSpatialTable("orbisgis").limit(1) as CustomPrinter.Ascii).toString())
+                "|        ID         |     THE_GEOM      |VERY_LONG_TITLE_...|\n" +
+                "+-------------------+-------------------+-------------------+\n" +
+                "|                  1|POINT (10 10)      |just a string a ...|\n" +
+                "+-------------------+-------------------+-------------------+\n",
+                (h2GIS.getSpatialTable("orbisgis").limit(1) as Ascii).toString())
     }
 }

--- a/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
+++ b/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.Point
 import org.orbisgis.commons.printer.Ascii
+import org.orbisgis.commons.printer.Html
 import org.orbisgis.datamanager.h2gis.H2GIS
 import org.orbisgis.datamanagerapi.dataset.ISpatialTable
 import org.orbisgis.datamanagerapi.dataset.ITable
@@ -523,8 +524,6 @@ class GroovyH2GISTest {
         assertNull h2GIS.load(osmFile, "OSM")
         assertNull h2GIS.load(osmFile, "OSM", true)
 
-        println h2GIS.getTable("INFORMATION_SCHEMA.COLUMNS") as Ascii
-
         h2GIS.eachRow "SELECT count(TABLE_NAME) as nb FROM INFORMATION_SCHEMA.TABLES where TABLE_NAME LIKE 'OSM%'",
                 { row ->
                     assertEquals 11,row.nb
@@ -595,5 +594,27 @@ class GroovyH2GISTest {
                 "|                  1|POINT (10 10)      |just a string a ...|\n" +
                 "+-------------------+-------------------+-------------------+\n",
                 (h2GIS.getSpatialTable("orbisgis").limit(1) as Ascii).toString())
+        assertEquals "<table>\n" +
+                "<caption>ORBISGIS</caption>\n" +
+                "<tr></tr>\n" +
+                "<tr>\n" +
+                "<th align=\"CENTER\">ID</th>\n" +
+                "<th align=\"CENTER\">THE_GEOM</th>\n" +
+                "<th align=\"CENTER\">VERY_LONG_TITLE_TO_TEST_SIZE_LIMITS</th>\n" +
+                "</tr>\n" +
+                "<tr></tr>\n" +
+                "<tr>\n" +
+                "<td align=\"RIGHT\">1</td>\n" +
+                "<td align=\"LEFT\">POINT (10 10)</td>\n" +
+                "<td align=\"LEFT\">just a string a bit too long</td>\n" +
+                "</tr>\n" +
+                "<tr>\n" +
+                "<td align=\"RIGHT\">2</td>\n" +
+                "<td align=\"LEFT\">POINT (1 1)</td>\n" +
+                "<td align=\"LEFT\">another string</td>\n" +
+                "</tr>\n" +
+                "<tr></tr>\n" +
+                "</table>\n",
+                (h2GIS.getSpatialTable("orbisgis") as Html).toString()
     }
 }

--- a/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
+++ b/data-manager/src/test/groovy/org/orbisgis/datamanager/GroovyH2GISTest.groovy
@@ -39,6 +39,7 @@ package org.orbisgis.datamanager
 import org.junit.jupiter.api.Test
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.Point
+import org.orbisgis.commons.printer.CustomPrinter
 import org.orbisgis.datamanager.h2gis.H2GIS
 import org.orbisgis.datamanagerapi.dataset.ISpatialTable
 import org.orbisgis.datamanagerapi.dataset.ITable
@@ -522,6 +523,8 @@ class GroovyH2GISTest {
         assertNull h2GIS.load(osmFile, "OSM")
         assertNull h2GIS.load(osmFile, "OSM", true)
 
+        println h2GIS.getTable("INFORMATION_SCHEMA.COLUMNS") as CustomPrinter.Ascii
+
         h2GIS.eachRow "SELECT count(TABLE_NAME) as nb FROM INFORMATION_SCHEMA.TABLES where TABLE_NAME LIKE 'OSM%'",
                 { row ->
                     assertEquals 11,row.nb
@@ -562,5 +565,31 @@ class GroovyH2GISTest {
         h2GIS.getSpatialTable("orbisgis").the_geom.createSpatialIndex()
         assertTrue h2GIS.getSpatialTable("orbisgis").the_geom.indexed
         assertTrue h2GIS.getSpatialTable("orbisgis").the_geom.spatialIndexed
+    }
+
+    @Test
+    void testPrint(){
+        def h2GIS = H2GIS.open('./target/orbisgis')
+        h2GIS.execute("""
+                DROP TABLE IF EXISTS orbisgis;
+                CREATE TABLE orbisgis (id int, the_geom point, very_long_title_to_test_size_limits varchar);
+                INSERT INTO orbisgis VALUES (1, 'POINT(10 10)'::GEOMETRY, 'just a string a bit too long'), 
+                (2, 'POINT(1 1)'::GEOMETRY, 'another string');
+        """)
+        assertEquals(
+                "+-------------------+-------------------+-------------------+\n" +
+                        "|        ID         |     THE_GEOM      |VERY_LONG_TITLE_...|\n" +
+                        "+-------------------+-------------------+-------------------+\n" +
+                        "|1                  |POINT (10 10)      |just a string a ...|\n" +
+                        "|2                  |POINT (1 1)        |another string     |\n" +
+                        "+-------------------+-------------------+-------------------+\n",
+                (h2GIS.getSpatialTable("orbisgis") as CustomPrinter.Ascii).toString())
+        assertEquals(
+                "+-------------------+-------------------+-------------------+\n" +
+                        "|        ID         |     THE_GEOM      |VERY_LONG_TITLE_...|\n" +
+                        "+-------------------+-------------------+-------------------+\n" +
+                        "|1                  |POINT (10 10)      |just a string a ...|\n" +
+                        "+-------------------+-------------------+-------------------+\n",
+                (h2GIS.getSpatialTable("orbisgis").limit(1) as CustomPrinter.Ascii).toString())
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
+        <module>common</module>
         <module>data-manager-api</module>
         <module>data-manager</module>
         <module>process-manager-api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
-        <module>common</module>
+        <module>commons</module>
         <module>data-manager-api</module>
         <module>data-manager</module>
         <module>process-manager-api</module>


### PR DESCRIPTION
Add the module `commons` with common resources for all modules.
Add classes to allow using the `asType(Class)` of `JdbcTable` to print it in Ascii or HTML.
Linked to #106 

Usage example in groovy :
``` groovy
def h2gis = H2GIS.open('./orbisgis')
h2gis.execute("""
                DROP TABLE IF EXISTS orbisgis;
                CREATE TABLE orbisgis (id int, the_geom point, very_long_title_to_test_size_limits varchar);
                INSERT INTO orbisgis VALUES (1, 'POINT(10 10)'::GEOMETRY, 'just a string a bit too long'), 
                (2, 'POINT(1 1)'::GEOMETRY, 'another string');
""")
println h2gis.getTable("orbisgis") as Ascii
println h2gis.getTable("orbisgis").limit(1) as Ascii // To only print the first line
println h2gis.getTable("orbisgis") as Html
```