### PR TITLE
Rework ProcessMapper.

### DIFF
--- a/data-manager/src/main/java/org/orbisgis/datamanager/dsl/BuilderResult.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/dsl/BuilderResult.java
@@ -39,7 +39,6 @@ package org.orbisgis.datamanager.dsl;
 import groovy.lang.Closure;
 import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.wrapper.StatementWrapper;
-import org.orbisgis.commons.printer.Ascii;
 import org.orbisgis.commons.printer.ICustomPrinter;
 import org.orbisgis.datamanager.JdbcDataSource;
 import org.orbisgis.datamanager.h2gis.H2gisSpatialTable;
@@ -54,7 +53,6 @@ import org.slf4j.LoggerFactory;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.UUID;
 
 /**
  * Implementation of IBuilderResult

--- a/process-manager-api/pom.xml
+++ b/process-manager-api/pom.xml
@@ -32,6 +32,17 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build Settings -->

--- a/process-manager-api/src/main/java/org/orbisgis/processmanagerapi/ILinker.java
+++ b/process-manager-api/src/main/java/org/orbisgis/processmanagerapi/ILinker.java
@@ -36,39 +36,27 @@
  */
 package org.orbisgis.processmanagerapi;
 
-import java.util.UUID;
-
-
 /**
- * This class should not be used will using a IProcess executing and mapping processes is easier.
+ * This interface declare the methods used to link inputs, outputs and aliases. The first element to link is given
+ * through the constructor, the second through the methods {@link ILinker#to(String)} or
+ * {@link ILinker#to(IProcessInOutPut[])}.
  *
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface IProcessMapper extends IProcess {
+public interface ILinker {
 
     /**
-     * Start to link the given inputs/outputs.
+     * Second element to link.
      *
-     * @param inOutPuts Inputs or outputs to link.
-     *
-     * @return A {@link ILinker} object which will do the link.
+     * @param inOutPuts Inputs or Outputs to link.
      */
-    ILinker link(IProcessInOutPut... inOutPuts);
+    void to(IProcessInOutPut... inOutPuts);
 
-    default String getVersion(){
-        return null;
-    }
-
-    default String getDescription(){
-        return null;
-    }
-
-    default String[] getKeywords(){
-        return null;
-    }
-
-    default String getIdentifier(){
-        return UUID.randomUUID().toString();
-    }
+    /**
+     * Alias to give to the inputs or outputs.
+     *
+     * @param alias Alias to use.
+     */
+    void to(String alias);
 }

--- a/process-manager-api/src/main/java/org/orbisgis/processmanagerapi/IProcessInOutPut.java
+++ b/process-manager-api/src/main/java/org/orbisgis/processmanagerapi/IProcessInOutPut.java
@@ -36,39 +36,25 @@
  */
 package org.orbisgis.processmanagerapi;
 
-import java.util.UUID;
-
-
 /**
- * This class should not be used will using a IProcess executing and mapping processes is easier.
+ * This interface defines the methods dedicated the wrapping of input/output.
  *
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface IProcessMapper extends IProcess {
+public interface IProcessInOutPut {
 
     /**
-     * Start to link the given inputs/outputs.
+     * Return the input/output name.
      *
-     * @param inOutPuts Inputs or outputs to link.
-     *
-     * @return A {@link ILinker} object which will do the link.
+     * @return The input/output name.
      */
-    ILinker link(IProcessInOutPut... inOutPuts);
+    String getName();
 
-    default String getVersion(){
-        return null;
-    }
-
-    default String getDescription(){
-        return null;
-    }
-
-    default String[] getKeywords(){
-        return null;
-    }
-
-    default String getIdentifier(){
-        return UUID.randomUUID().toString();
-    }
+    /**
+     * Return the {@link IProcess} of the input/output.
+     *
+     * @return The {@link IProcess} of the input/output.
+     */
+    IProcess getProcess();
 }

--- a/process-manager-api/src/main/java/org/orbisgis/processmanagerapi/IProcessMapper.java
+++ b/process-manager-api/src/main/java/org/orbisgis/processmanagerapi/IProcessMapper.java
@@ -38,7 +38,6 @@ package org.orbisgis.processmanagerapi;
 
 import java.util.UUID;
 
-
 /**
  * This class should not be used will using a IProcess executing and mapping processes is easier.
  *

--- a/process-manager-api/src/test/java/org/orbisgis/processmanagerapi/IProcessMapperTest.java
+++ b/process-manager-api/src/test/java/org/orbisgis/processmanagerapi/IProcessMapperTest.java
@@ -1,0 +1,104 @@
+/*
+ * Bundle ProcessManager API is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * ProcessManager API is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * ProcessManager API is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * ProcessManager API is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * ProcessManager API. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.processmanagerapi;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test class dedicated to {@link IProcessMapper} interface.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public class IProcessMapperTest {
+
+    /**
+     * Test the {@link IProcessMapper#getVersion()} method.
+     */
+    @Test
+    public void testGetVersion(){
+        assertNull(new DummyProcessMapper().getVersion());
+    }
+
+    /**
+     * Test the {@link IProcessMapper#getDescription()} method.
+     */
+    @Test
+    public void testGetDescription(){
+        assertNull(new DummyProcessMapper().getDescription());
+    }
+
+    /**
+     * Test the {@link IProcessMapper#getKeywords()} method.
+     */
+    @Test
+    public void testGetKeyword(){
+        assertNull(new DummyProcessMapper().getKeywords());
+    }
+
+    /**
+     * Test the {@link IProcessMapper#getIdentifier()} method.
+     */
+    @Test
+    public void testGetIdentifier(){
+        Pattern pattern = Pattern.compile("[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}");
+        Matcher matcher = pattern.matcher(new DummyProcessMapper().getIdentifier());
+        assertTrue(matcher.find());
+    }
+
+    /**
+     * Simple implementtion of the {@link IProcessMapper} interface.
+     */
+    private class DummyProcessMapper implements IProcessMapper {
+
+        @Override public ILinker link(IProcessInOutPut... inOutPuts) {return null;}
+        @Override public IProcess newInstance() {return null;}
+        @Override public boolean execute(LinkedHashMap<String, Object> inputDataMap) {return false;}
+        @Override public String getTitle() {return null;}
+        @Override public Map<String, Object> getResults() {return null;}
+        @Override public Map<String, Class> getInputs() {return null;}
+        @Override public Map<String, Class> getOutputs() {return null;}
+    }
+}

--- a/process-manager/src/main/java/org/orbisgis/processmanager/Process.java
+++ b/process-manager/src/main/java/org/orbisgis/processmanager/Process.java
@@ -37,6 +37,7 @@
 package org.orbisgis.processmanager;
 
 import groovy.lang.Closure;
+import groovy.lang.GroovyObject;
 import groovy.lang.MetaClass;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.orbisgis.processmanagerapi.ICaster;
@@ -50,13 +51,13 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * Implementation of the IProcess interface dedicated to the local creation and execution of process (no link with
+ * Implementation of the {@link IProcess} interface dedicated to the local creation and execution of process (no link with
  * WPS process for now).
  *
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)
  */
-public class Process implements IProcess {
+public class Process implements IProcess, GroovyObject {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Process.class);
 
@@ -271,5 +272,33 @@ public class Process implements IProcess {
     @Override
     public Map<String, Class> getOutputs() {
         return outputs;
+    }
+
+    @Override
+    public Object invokeMethod(String name, Object args) {
+        return metaClass.invokeMethod(this, name, args);
+    }
+
+    @Override
+    public Object getProperty(String propertyName) {
+        if(inputs.keySet().contains(propertyName) || outputs.keySet().contains(propertyName)){
+            return new ProcessInOutPut(this, propertyName);
+        }
+        return metaClass.getProperty(this, propertyName);
+    }
+
+    @Override
+    public void setProperty(String propertyName, Object newValue) {
+        this.metaClass.setProperty(this, propertyName, newValue);
+    }
+
+    @Override
+    public MetaClass getMetaClass() {
+        return metaClass;
+    }
+
+    @Override
+    public void setMetaClass(MetaClass metaClass) {
+        this.metaClass = metaClass;
     }
 }

--- a/process-manager/src/main/java/org/orbisgis/processmanager/Process.java
+++ b/process-manager/src/main/java/org/orbisgis/processmanager/Process.java
@@ -195,6 +195,7 @@ public class Process implements IProcess, GroovyObject {
 
     @Override
     public boolean execute(LinkedHashMap<String, Object> inputDataMap) {
+        LOGGER.debug("Starting the execution of '" + this.getTitle() + "'.");
         if(inputs != null && (inputs.size() < inputDataMap.size() || inputs.size()-defaultValues.size() > inputDataMap.size())){
             LOGGER.error("The number of the input data map and the number of process input are different, should" +
                     " be between " + (inputDataMap.size()-defaultValues.size()) + " and " + inputDataMap.size() + ".");
@@ -225,6 +226,7 @@ public class Process implements IProcess, GroovyObject {
         for (Map.Entry<String, Class> entry : outputs.entrySet()) {
             isResultValid = map.containsKey(entry.getKey());
         }
+        LOGGER.debug("End of the execution of '" + this.getTitle() + "'.");
         if(!isResultValid){
             return false;
         }

--- a/process-manager/src/main/java/org/orbisgis/processmanager/ProcessInOutPut.java
+++ b/process-manager/src/main/java/org/orbisgis/processmanager/ProcessInOutPut.java
@@ -1,5 +1,5 @@
 /*
- * Bundle ProcessManager API is part of the OrbisGIS platform
+ * Bundle ProcessManager is part of the OrbisGIS platform
  *
  * OrbisGIS is a java GIS application dedicated to research in GIScience.
  * OrbisGIS is developed by the GIS group of the DECIDE team of the
@@ -13,62 +13,62 @@
  * Institut Universitaire de Technologie de Vannes
  * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
  *
- * ProcessManager API is distributed under GPL 3 license.
+ * ProcessManager is distributed under GPL 3 license.
  *
  * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
  *
  *
- * ProcessManager API is free software: you can redistribute it and/or modify it under the
+ * ProcessManager is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
  * Foundation, either version 3 of the License, or (at your option) any later
  * version.
  *
- * ProcessManager API is distributed in the hope that it will be useful, but WITHOUT ANY
+ * ProcessManager is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with
- * ProcessManager API. If not, see <http://www.gnu.org/licenses/>.
+ * ProcessManager. If not, see <http://www.gnu.org/licenses/>.
  *
  * For more information, please consult: <http://www.orbisgis.org/>
  * or contact directly:
  * info_at_ orbisgis.org
  */
-package org.orbisgis.processmanagerapi;
+package org.orbisgis.processmanager;
 
-import java.util.UUID;
-
+import org.orbisgis.processmanagerapi.IProcess;
+import org.orbisgis.processmanagerapi.IProcessInOutPut;
 
 /**
- * This class should not be used will using a IProcess executing and mapping processes is easier.
+ * Implementation of the {@link IProcessInOutPut} interface.
  *
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)
  */
-public interface IProcessMapper extends IProcess {
+public class ProcessInOutPut implements IProcessInOutPut {
+    /** {@link IProcess} of the input/output. */
+    private IProcess process;
+    /** Name of the input/output. */
+    private String name;
 
     /**
-     * Start to link the given inputs/outputs.
+     * Main constructor.
      *
-     * @param inOutPuts Inputs or outputs to link.
-     *
-     * @return A {@link ILinker} object which will do the link.
+     * @param process {@link IProcess} of the input/output.
+     * @param name Name of the input/output.
      */
-    ILinker link(IProcessInOutPut... inOutPuts);
-
-    default String getVersion(){
-        return null;
+    public ProcessInOutPut(IProcess process, String name){
+        this.process = process;
+        this.name = name;
     }
 
-    default String getDescription(){
-        return null;
+    public String getName(){
+        return name;
     }
 
-    default String[] getKeywords(){
-        return null;
+    public IProcess getProcess() {
+        return process;
     }
 
-    default String getIdentifier(){
-        return UUID.randomUUID().toString();
-    }
+    @Override public String toString(){return name+":"+process.getIdentifier();}
 }

--- a/process-manager/src/main/java/org/orbisgis/processmanager/ProcessMapper.java
+++ b/process-manager/src/main/java/org/orbisgis/processmanager/ProcessMapper.java
@@ -36,7 +36,9 @@
  */
 package org.orbisgis.processmanager;
 
+import org.orbisgis.processmanagerapi.ILinker;
 import org.orbisgis.processmanagerapi.IProcess;
+import org.orbisgis.processmanagerapi.IProcessInOutPut;
 import org.orbisgis.processmanagerapi.IProcessMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,97 +53,92 @@ import java.util.stream.Collectors;
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)
  */
-@Deprecated
 public class ProcessMapper implements IProcessMapper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessMapper.class);
 
-    private Map<ProcessOutput, ProcessInput> inOutMap;
     private Map<String, Class> inputs;
     private Map<String, Class> outputs;
     private List<List<String>> executionTree;
     private Map<String, Object> results;
-    private List<Link> linkingList;
-    private Map<String, IProcess> processMap;
-    private Map<String, List<Map<String, IProcess>>> aliases;
+    /** Map with the input as key and the output as value. */
+    private Map<IProcessInOutPut, IProcessInOutPut> inputOutputMap;
+    /** List of all the processes used in this mapper. */
+    private List<IProcess> processList;
+    /** Map of the aliases as key and the list of input/output as value. */
+    private Map<String, List<IProcessInOutPut>> aliases;
 
+    /**
+     * Main constructor.
+     */
     public ProcessMapper(){
-        linkingList = new ArrayList<>();
+        inputOutputMap = new HashMap<>();
         aliases = new HashMap<>();
     }
 
-    private String getUuidOfProcess(IProcess process){
-        for(Map.Entry<String, IProcess> entry : processMap.entrySet()){
-            if(entry.getValue().equals(process)){
-                return entry.getKey();
-            }
-        }
-        return null;
-    }
-
-    private String getAlias(String inputOrOutput, IProcess process){
-        for(Map.Entry<String, List<Map<String, IProcess>>> list : aliases.entrySet()){
-            for(Map<String, IProcess> map : list.getValue()) {
-                for (Map.Entry<String, IProcess> entry : map.entrySet()) {
-                    if (entry.getKey().equals(inputOrOutput) && entry.getValue().equals(process)) {
-                        return list.getKey();
-                    }
+    /**
+     * Return the alias of the given input or output.
+     *
+     * @param name
+     * @param process
+     *
+     * @return The alias name if there is one, null otherwise.
+     */
+    private String getAlias(String name, IProcess process){
+        for(Map.Entry<String, List<IProcessInOutPut>> list : aliases.entrySet()){
+            for(IProcessInOutPut inOutPut : list.getValue()) {
+                if (inOutPut.getName().equals(name) && inOutPut.getProcess().getIdentifier().equals(process.getIdentifier())) {
+                    return list.getKey();
                 }
             }
         }
         return null;
     }
 
+    /**
+     * Link the inputs, the outputs and the aliases to prepare the execution.
+     */
     private void link(){
-        inOutMap = new HashMap<>();
         inputs = new HashMap<>();
         outputs = new HashMap<>();
         executionTree = new ArrayList<>();
         results = new HashMap<>();
-        processMap = new HashMap<>();
+        processList = new ArrayList<>();
 
-        List<ProcessInput> availableIn = new ArrayList<>();
+        List<IProcessInOutPut> availableIn = new ArrayList<>();
 
         //Build the map linking the inputs and outputs.
-        linkingList.forEach(link -> {
-            String output = link.getOutName();
-            String input = link.getInName();
-            IProcess outputProcess = link.getOutProcess();
-            IProcess inputProcess = link.getInProcess();
-            if (!processMap.values().contains(outputProcess)) {
-                processMap.put(UUID.randomUUID().toString(), outputProcess);
+        inputOutputMap.forEach((input, output) -> {
+            if (!processList.contains(input.getProcess())) {
+                processList.add(input.getProcess());
             }
-            if (!processMap.values().contains(inputProcess)) {
-                processMap.put(UUID.randomUUID().toString(), inputProcess);
+            if (!processList.contains(output.getProcess())) {
+                processList.add(output.getProcess());
             }
-            inOutMap.put(new ProcessOutput(output, getUuidOfProcess(outputProcess)),
-                    new ProcessInput(input, getUuidOfProcess(inputProcess)));
         });
 
         //Get all the inputs and outputs of the processes.
-        for (String uuid : processMap.keySet()) {
-            IProcess process = processMap.get(uuid);
+        for (IProcess process : processList) {
             if(process.getInputs() != null) {
                 process.getInputs().forEach((key, value) -> {
                     boolean isBetween = false;
-                    for (Map.Entry<ProcessOutput, ProcessInput> entry : inOutMap.entrySet()) {
-                        if (entry.getValue().getInput().equals(key) &&
-                                entry.getValue().getProcessId().equals(uuid)) {
+                    for (Map.Entry<IProcessInOutPut, IProcessInOutPut> entry : inputOutputMap.entrySet()) {
+                        if (entry.getKey().getName().equals(key) &&
+                                entry.getKey().getProcess().getIdentifier().equals(process.getIdentifier())) {
                             isBetween = true;
                         }
                     }
                     if (!isBetween) {
-
                         inputs.put(key, value);
-                        availableIn.add(new ProcessInput(key, uuid));
+                        availableIn.add(new ProcessInOutPut(process, key));
                     }
                 });
             }
             process.getOutputs().forEach((key, value) -> {
                 boolean isBetween = false;
-                for(Map.Entry<ProcessOutput, ProcessInput> entry : inOutMap.entrySet()) {
-                    if (entry.getKey().getOutput().equals(key) &&
-                            entry.getKey().getProcessId().equals(uuid)) {
+                for(Map.Entry<IProcessInOutPut, IProcessInOutPut> entry : inputOutputMap.entrySet()) {
+                    if (entry.getValue().getName().equals(key) &&
+                            entry.getValue().getProcess().getIdentifier().equals(process.getIdentifier())) {
                         isBetween = true;
                     }
                 }
@@ -152,23 +149,23 @@ public class ProcessMapper implements IProcessMapper {
         }
 
         //Build the execution tree
-        List<String> processes = new ArrayList<>(processMap.keySet());
+        List<IProcess> iterableProcessList = new ArrayList<>(processList);
         int i = 0;
-        List<ProcessInput> newIn = new ArrayList<>();
+        List<IProcessInOutPut> newIn = new ArrayList<>();
         do {
             availableIn.addAll(newIn);
             newIn = new ArrayList<>();
             executionTree.add(new ArrayList<>());
-            for (Iterator<String> iterator = processes.iterator(); iterator.hasNext(); ) {
-                String uuid = iterator.next();
-                IProcess process = processMap.get(uuid);
+            for (Iterator<IProcess> iterator = iterableProcessList.iterator(); iterator.hasNext(); ) {
+                IProcess process = iterator.next();
+                String uuid = process.getIdentifier();
                 boolean isAllInput = true;
-                if(process.getInputs() != null) {
+                if (process.getInputs() != null) {
                     for (String input : process.getInputs().keySet()) {
                         boolean isInputAvailable = false;
-                        for (ProcessInput processInput : availableIn) {
-                            if (processInput.getInput().equals(input) &&
-                                    processInput.getProcessId().equals(uuid)) {
+                        for (IProcessInOutPut processInput : availableIn) {
+                            if (processInput.getName().equals(input) &&
+                                    processInput.getProcess().getIdentifier().equals(uuid)) {
                                 isInputAvailable = true;
                                 break;
                             }
@@ -182,10 +179,10 @@ public class ProcessMapper implements IProcessMapper {
                 if (isAllInput) {
                     executionTree.get(i).add(uuid);
                     for (String name : process.getOutputs().keySet()) {
-                        for (Map.Entry<ProcessOutput, ProcessInput> entry : inOutMap.entrySet()) {
-                            if (entry.getKey().getOutput().equals(name) &&
-                                    entry.getKey().getProcessId().equals(uuid)) {
-                                newIn.add(entry.getValue());
+                        for (Map.Entry<IProcessInOutPut, IProcessInOutPut> entry : inputOutputMap.entrySet()) {
+                            if (entry.getValue().getName().equals(name) &&
+                                    entry.getValue().getProcess().getIdentifier().equals(uuid)) {
+                                newIn.add(entry.getKey());
                             }
                         }
                     }
@@ -193,37 +190,38 @@ public class ProcessMapper implements IProcessMapper {
                 }
             }
             i++;
-        } while(!processes.isEmpty() && !executionTree.get(i-1).isEmpty());
+        } while(!iterableProcessList.isEmpty() && !executionTree.get(i-1).isEmpty());
 
-        if(!processes.isEmpty()){
+        if(!iterableProcessList.isEmpty()){
             LOGGER.error("Unable to link the processes '"+
-                    processes.stream().map(s -> processMap.get(s).getTitle()).collect(Collectors.joining(","))+"'");
+                    iterableProcessList.stream().map(IProcess::getTitle).collect(Collectors.joining(","))+"'");
         }
     }
 
-
     @Override
-    public Set<String> getInputNames() {
-        return getInputDefinitions().keySet();
-    }
-
-    @Override
-    public Set<String> getOutputNames() {
-        return getOutputDefinitions().keySet();
-    }
-
-    @Override
-    public Map<String, Class> getInputDefinitions() {
+    public Map<String, Class> getInputs() {
         return inputs;
     }
 
     @Override
-    public Map<String, Class> getOutputDefinitions() {
+    public Map<String, Class> getOutputs() {
         return outputs;
     }
 
     @Override
-    public boolean execute(Map<String, Object> inputDataMap) {
+    public IProcess newInstance() {
+        ProcessMapper mapper = new ProcessMapper();
+        mapper.aliases = aliases;
+        mapper.processList = new ArrayList<>(processList);
+        mapper.inputOutputMap = new HashMap<>(inputOutputMap);
+        mapper.executionTree = new ArrayList<>(executionTree);
+        mapper.inputs = new HashMap<>(inputs);
+        mapper.outputs = new HashMap<>(outputs);
+        return mapper;
+    }
+
+    @Override
+    public boolean execute(LinkedHashMap<String, Object> inputDataMap) {
         link();
         Map<String, Object> dataMap = inputDataMap == null ?  new HashMap<>() : new HashMap<>(inputDataMap);
         /*if(inputs != null && dataMap.size() != inputs.size()){
@@ -232,49 +230,58 @@ public class ProcessMapper implements IProcessMapper {
         }*/
         for(List<String> uuids : executionTree){
             for(String uuid : uuids){
-                IProcess process = processMap.get(uuid);
+                IProcess process = null;
+                for(IProcess p : processList){
+                    if(p.getIdentifier().equals(uuid)){
+                        process = p;
+                    }
+                }
+                if(process == null){
+                    LOGGER.error("Unable to find the process with the identifier '"+uuid+"'.");
+                    return false;
+                }
                 LinkedHashMap<String, Object> processInData = new LinkedHashMap<>();
                 if(process.getInputs() != null) {
                     for (String in : process.getInputs().keySet()) {
                         //Try to get the data directly from the out of a process
                         String alias = getAlias(in, process);
-                        Object data;
+                        final Object[] data = new Object[1];
                         if(alias != null){
-                            data = dataMap.get(alias);
+                            data[0] = dataMap.get(alias);
                         }
                         else {
-                            data = dataMap.get(in);
+                            data[0] = dataMap.get(in);
                         }
                         //Get the link between the input 'in' and a process output if exists
-                        for(Link link : linkingList){
-                            if(uuid.equals(getUuidOfProcess(link.getInProcess())) &&
-                                    link.getInName().equals(in)){
+                        inputOutputMap.forEach((input, output) -> {
+                            if(uuid.equals(input.getProcess().getIdentifier()) &&
+                                    input.getName().equals(in)){
                                 //get the process with the output linked to 'in'
-                                for(String id : processMap.keySet()){
-                                    if(id.equals(getUuidOfProcess(link.getOutProcess()))){
-                                        data = processMap.get(id).getResults().get(link.getOutName());
+                                for(IProcess p : processList){
+                                    if(p.getIdentifier().equals(output.getProcess().getIdentifier())){
+                                        data[0] = p.getResults().get(output.getName());
                                     }
                                 }
                             }
-                        }
-                        processInData.put(in, data);
+                        });
+                        processInData.put(in, data[0]);
                     }
                 }
                 process.execute(processInData);
                 for(String key : process.getResults().keySet()){
                     boolean isBetween = false;
-                    for(Map.Entry<ProcessOutput, ProcessInput> entry : inOutMap.entrySet()){
-                        if(entry.getKey().getOutput().equals(key) &&
-                                entry.getKey().getProcessId().equals(uuid)){
+                    for(Map.Entry<IProcessInOutPut, IProcessInOutPut> entry : inputOutputMap.entrySet()){
+                        if(entry.getKey().getName().equals(key) &&
+                                entry.getKey().getProcess().getIdentifier().equals(uuid)){
                             isBetween = true;
                         }
                     }
-                    if(!isBetween){
-                        String alias = getAlias(key, process);
-                        if(alias != null){
-                            results.put(alias, process.getResults().get(key));
-                        }
-                        else {
+                    String alias = getAlias(key, process);
+                    if(alias != null){
+                        results.put(alias, process.getResults().get(key));
+                    }
+                    else {
+                        if(!isBetween){
                             results.put(key, process.getResults().get(key));
                         }
                     }
@@ -285,122 +292,116 @@ public class ProcessMapper implements IProcessMapper {
     }
 
     @Override
+    public String getTitle() {
+        return null;
+    }
+
+    @Override
     public Map<String, Object> getResults() {
         return results;
     }
 
     @Override
-    public void link(Map<String, IProcess> map) {
-        if (map == null || map.isEmpty()) {
-            LOGGER.error("The in/output is null or empty");
+    public ILinker link(IProcessInOutPut... inOutPuts) {
+        return new Linker(inOutPuts);
+    }
+
+    /**
+     * This class manage the link between inputs, outputs and aliases.
+     */
+    private class Linker implements ILinker {
+        /** Array of inputs */
+        private List<IProcessInOutPut> inputs = new ArrayList<>();
+        /** Array of outputs */
+        private List<IProcessInOutPut> outputs = new ArrayList<>();
+
+        /**
+         * Main constructor.
+         *
+         * @param inOutPuts Inputs or outputs to link.
+         */
+        private Linker(IProcessInOutPut... inOutPuts){
+            if(inOutPuts.length == 0){
+                LOGGER.error("The input/output list should not be empty.");
+            }
+            boolean allInputs = true;
+            boolean allOutputs = true;
+            for(IProcessInOutPut inOutPut : inOutPuts){
+                if(!inOutPut.getProcess().getInputs().keySet().contains(inOutPut.getName())){
+                    allInputs = false;
+                }
+                if(!inOutPut.getProcess().getOutputs().keySet().contains(inOutPut.getName())){
+                    allOutputs = false;
+                }
+            }
+            if(!allInputs && !allOutputs){
+                LOGGER.error("Input and outputs should not be mixed.");
+            }
+            else if(allInputs){
+                inputs.addAll(Arrays.asList(inOutPuts));
+            }
+            else{
+                outputs.addAll(Arrays.asList(inOutPuts));
+            }
         }
-        else if (map.size() != 2) {
-            LOGGER.error("The in/output should contains two value");
+
+        @Override
+        public void to(IProcessInOutPut... inOutPuts) {
+            if(!inputs.isEmpty()) {
+                boolean allOutputs = true;
+                for(IProcessInOutPut inOutPut : inOutPuts){
+                    if(!inOutPut.getProcess().getOutputs().keySet().contains(inOutPut.getName())){
+                        allOutputs = false;
+                    }
+                }
+                if(!allOutputs){
+                    LOGGER.error("Inputs should be link to outputs.");
+                    return;
+                }
+                outputs.addAll(Arrays.asList(inOutPuts));
+            }
+            if(!outputs.isEmpty()) {
+                boolean allInputs = true;
+                for(IProcessInOutPut inOutPut : inOutPuts){
+                    if(!inOutPut.getProcess().getInputs().keySet().contains(inOutPut.getName())){
+                        allInputs = false;
+                    }
+                }
+                if(!allInputs){
+                    LOGGER.error("Outputs should be link to inputs.");
+                    return;
+                }
+                inputs.addAll(Arrays.asList(inOutPuts));
+            }
+            for (IProcessInOutPut input : inputs) {
+                for(IProcessInOutPut output : outputs) {
+                    inputOutputMap.put(input, output);
+                }
+            }
         }
-        else {
-            Link link = new Link();
-            linkingList.add(link);
-            Iterator<Map.Entry<String, IProcess>> it = map.entrySet().iterator();
-            Map.Entry<String, IProcess> entry = it.next();
-            link.setOut(entry.getKey(), entry.getValue());
-            entry = it.next();
-            link.setIn(entry.getKey(), entry.getValue());
+
+        @Override
+        public void to(String alias) {
+            List<IProcessInOutPut> inOutPuts = new ArrayList<>();
+            inOutPuts.addAll(inputs);
+            inOutPuts.addAll(outputs);
+            for (IProcessInOutPut inOutPut : inOutPuts) {
+                if(aliases.get(alias) != null ) {
+                    aliases.get(alias).add(inOutPut);
+                }
+                else {
+                    aliases.put(alias, new ArrayList<>(inOutPuts));
+                }
+            }
         }
     }
 
-    @Override
-    public void alias(Map<String, IProcess> inputsOrOutputs, String alias) {
-        List<Map<String, IProcess>> list = aliases.get(alias);
-        if(list != null ) {
-            aliases.get(alias).add(inputsOrOutputs);
-        }
-        else {
-            aliases.put(alias, new ArrayList<>(Collections.singleton(inputsOrOutputs)));
-        }
-    }
-
-    private IProcess getProcess(String identifier){
-        if (processMap.isEmpty()) {
-            return null;
-        }
-        return processMap.values()
-                .stream()
-                .filter(iProcess -> iProcess.getIdentifier().equals(identifier))
-                .findFirst()
-                .orElse(null);
-
-    }
-
-    private class ProcessOutput{
-        private String output;
-        private String processId;
-
-        ProcessOutput(String output, String processId){
-            this.output = output;
-            this.processId = processId;
-        }
-
-        String getProcessId(){
-            return processId;
-        }
-
-        String getOutput(){
-            return output;
-        }
-
-        @Override public String toString(){return output+":"+processId;}
-    }
-
-    private class ProcessInput{
-        private String input;
-        private String processId;
-
-        ProcessInput(String input, String processId){
-            this.input = input;
-            this.processId = processId;
-        }
-
-        String getProcessId(){
-            return processId;
-        }
-
-        String getInput(){
-            return input;
-        }
-
-        @Override public String toString(){return input+":"+processId;}
-    }
-
-    private class Link {
-        private String inName;
-        private IProcess inProcess;
-        private String outName;
-        private IProcess outProcess;
-
-        void setIn(String inName, IProcess inProcess){
-            this.inName = inName;
-            this.inProcess = inProcess;
-        }
-
-        void setOut(String outName, IProcess outProcess){
-            this.outName = outName;
-            this.outProcess = outProcess;
-        }
-
-        String getInName(){
-            return inName;
-        }
-
-        String getOutName(){
-            return outName;
-        }
-
-        IProcess getInProcess(){
-            return inProcess;
-        }
-
-        IProcess getOutProcess(){
-            return outProcess;
-        }
+    @Deprecated
+    public void link(LinkedHashMap<String, IProcess> map){
+        Iterator<Map.Entry<String, IProcess>> it = map.entrySet().iterator();
+        Map.Entry<String, IProcess> inputEntry = it.next();
+        Map.Entry<String, IProcess> outputEntry = it.next();
+        link(new ProcessInOutPut(inputEntry.getValue(), inputEntry.getKey()))
+                .to(new ProcessInOutPut(outputEntry.getValue(), outputEntry.getKey()));
     }
 }

--- a/process-manager/src/test/groovy/org/orbisgis/processmanager/TestProcess.groovy
+++ b/process-manager/src/test/groovy/org/orbisgis/processmanager/TestProcess.groovy
@@ -186,7 +186,7 @@ class TestProcess {
         def pB = processManager.factory("map1").create("pB", [inB1:String], [outB1:String], {inB1 ->[outB1:inB1+inB1]})
 
         def mapper = new ProcessMapper()
-        mapper.link(outA1:pA, inB1:pB)
+        mapper.link(pA.outA1).to(pB.inB1)
         assertTrue mapper.execute([inA1: "t", inA2: "a"])
         assertEquals "tata", mapper.getResults().outB1
     }
@@ -210,9 +210,9 @@ class TestProcess {
                 {inC1, inC2 ->[outC1:inC1+inC2, outC2:inC2+inC1]})
 
         def mapper = new ProcessMapper()
-        mapper.link(outA1:pA,inB1:pB)
-        mapper.link(outB1:pB,inC2:pC)
-        mapper.link(outA1:pA,inC1:pC)
+        mapper.link(pA.outA1).to(pB.inB1)
+        mapper.link(pB.outB1).to(pC.inC2)
+        mapper.link(pA.outA1).to(pC.inC1)
 
         assertTrue mapper.execute([inA1: "a", inB2: "b"])
         assertEquals "AbA", mapper.getResults().outC1
@@ -238,10 +238,10 @@ class TestProcess {
                 {inD1, inD2 ->[outD1:inD1.toLowerCase(), outD2:inD2+inD1]})
 
         def mapper = new ProcessMapper()
-        mapper.link(outA1: pA,inB1: pB)
-        mapper.link(outA1: pA,inC1: pC)
-        mapper.link(outB1: pB,inD1: pD)
-        mapper.link(outC1: pC,inD2: pD)
+        mapper.link(pA.outA1).to(pB.inB1)
+        mapper.link(pA.outA1).to(pC.inC1)
+        mapper.link(pB.outB1).to(pD.inD1)
+        mapper.link(pC.outC1).to(pD.inD2)
 
         assertTrue mapper.execute([inA1: "a", inB2: "b", inC2: "c"])
         assertEquals "ba", mapper.getResults().outD1
@@ -260,10 +260,10 @@ class TestProcess {
         def pA3 = processManager.factory("map4").create("pA", [inA1:String, inA2:String], [outA1:String], {inA1, inA2 ->[outA1:inA1+inA2]})
 
         def mapper = new ProcessMapper()
-        mapper.link(outA1:pA1, inA1:pA2)
-        mapper.link(outA1:pA1, inA2:pA2)
-        mapper.link(outA1:pA2, inA1:pA3)
-        mapper.link(outA1:pA2, inA2:pA3)
+        mapper.link(pA1.outA1).to(pA2.inA1)
+        mapper.link(pA1.outA1).to(pA2.inA2)
+        mapper.link(pA2.outA1).to(pA3.inA1)
+        mapper.link(pA2.outA1).to(pA3.inA2)
         assertTrue mapper.execute([inA1: "t", inA2: "a"])
         assertEquals "tatatata", mapper.getResults().outA1
     }
@@ -286,23 +286,26 @@ class TestProcess {
 
         def mapper = new ProcessMapper()
 
-        mapper.link(outA1:pA1, inB1:pB1)
-        mapper.link(outA1:pA1, inB2:pB1)
-        mapper.link(outA1:pA2, inB1:pB2)
-        mapper.link(outA1:pA2, inB2:pB2)
+        mapper.link(pA1.outA1).to(pB1.inB1)
+        mapper.link(pA1.outA1).to(pB1.inB2)
+        mapper.link(pA2.outA1).to(pB2.inB1, pB2.inB2)
 
-        mapper.alias(inA1:pA1, "commonInput")
-        mapper.alias(inA1:pA2, "commonInput")
-        mapper.alias(inA2:pA1, "inputD")
-        mapper.alias(inA2:pA2, "inputK")
+        mapper.link(pA1.outA1).to("interPA1OutA1")
+        mapper.link(pA2.outA1).to("interPA2OutA1")
 
-        mapper.alias(outB1:pB1, "outD")
-        mapper.alias(outB1:pB2, "outK")
+        mapper.link(pA1.inA1, pA2.inA1).to("commonInput")
+        mapper.link(pA1.inA2).to("inputD")
+        mapper.link(pA2.inA2).to("inputK")
+
+        mapper.link(pB1.outB1).to("outD")
+        mapper.link(pB2.outB1).to("outK")
 
         assertTrue mapper.execute([inputD: "D", inputK: "K", commonInput: "common"])
         assertFalse mapper.getResults().containsKey("outB1")
         assertEquals "commonD or commonD", mapper.getResults().outD
         assertEquals "commonK or commonK", mapper.getResults().outK
+        assertEquals "commonK", mapper.getResults().interPA2OutA1
+        assertEquals "commonD", mapper.getResults().interPA1OutA1
     }
 }
 

--- a/process-manager/src/test/java/org/orbisgis/processmanager/ProcessMapperTest.java
+++ b/process-manager/src/test/java/org/orbisgis/processmanager/ProcessMapperTest.java
@@ -37,6 +37,7 @@
 package org.orbisgis.processmanager;
 
 import groovy.lang.Closure;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.orbisgis.processmanagerapi.IProcessInOutPut;
 import org.orbisgis.processmanagerapi.IProcessManager;
@@ -55,6 +56,73 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Sylvain PALOMINOS (UBS 2019)
  */
 public class ProcessMapperTest {
+
+    private static Process pA1;
+    private static Process pA2;
+    private static Process pB1;
+    private static Process pB2;
+
+    @BeforeAll
+    public static void init(){
+        LinkedHashMap<String, Object> pAInputMap = new LinkedHashMap<>();
+        pAInputMap.put("inA1", String.class);
+        pAInputMap.put("inA2", String.class);
+        LinkedHashMap<String, Object> pAOutputMap = new LinkedHashMap<>();
+        pAOutputMap.put("outA1", String.class);
+        pA1 = (Process)processManager.factory("map5").create("pA", pAInputMap, pAOutputMap, new Closure(null) {
+            public int getMaximumNumberOfParameters() {
+                return 2;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outA1", arguments[0].toString() + arguments[1].toString());
+                return map;
+            }
+        });
+
+        pA2 = (Process)processManager.factory("map5").create("pA", pAInputMap, pAOutputMap, new Closure(null) {
+            public int getMaximumNumberOfParameters() {
+                return 2;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outA1", arguments[0].toString() + arguments[1].toString());
+                return map;
+            }
+        });
+
+
+        LinkedHashMap<String, Object> pBInputMap = new LinkedHashMap<>();
+        pBInputMap.put("inB1", String.class);
+        pBInputMap.put("inB2", String.class);
+        LinkedHashMap<String, Object> pBOutputMap = new LinkedHashMap<>();
+        pBOutputMap.put("outB1", String.class);
+        pB1 = (Process)processManager.factory("map5").create("pB", pBInputMap, pBOutputMap, new Closure(null) {
+            public int getMaximumNumberOfParameters() {
+                return 2;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outB1", arguments[1].toString() + " or " + arguments[0].toString());
+                return map;
+            }
+        });
+
+        pB2 = (Process)processManager.factory("map5").create("pB", pBInputMap, pBOutputMap, new Closure(null) {
+            public int getMaximumNumberOfParameters() {
+                return 2;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outB1", arguments[1].toString() + " or " + arguments[0].toString());
+                return map;
+            }
+        });
+    }
 
     private static final IProcessManager processManager = ProcessManager.getProcessManager();
 
@@ -88,23 +156,6 @@ public class ProcessMapperTest {
             }
         });
 
-        LinkedHashMap<String, Object> pBInputMap = new LinkedHashMap<>();
-        pBInputMap.put("inB1", String.class);
-        pBInputMap.put("inB2", String.class);
-        LinkedHashMap<String, Object> pBOutputMap = new LinkedHashMap<>();
-        pBOutputMap.put("outB1", String.class);
-        Process pB = (Process)processManager.factory("map2").create("pB", pBInputMap, pBOutputMap, new Closure(this) {
-            public int getMaximumNumberOfParameters() {
-                return 2;
-            }
-            @Override
-            public Object call(Object... arguments) {
-                Map<String, Object> map = new HashMap<>();
-                map.put("outB1", arguments[1].toString() + arguments[0].toString());
-                return map;
-            }
-        });
-
         LinkedHashMap<String, Object> pCInputMap = new LinkedHashMap<>();
         pCInputMap.put("inC1", String.class);
         pCInputMap.put("inC2", String.class);
@@ -125,8 +176,8 @@ public class ProcessMapperTest {
         });
 
         IProcessMapper mapper = new ProcessMapper();
-        mapper.link((IProcessInOutPut)pA.getProperty("outA1")).to((IProcessInOutPut)pB.getProperty("inB1"));
-        mapper.link((IProcessInOutPut)pB.getProperty("outB1")).to((IProcessInOutPut)pC.getProperty("inC2"));
+        mapper.link((IProcessInOutPut)pA.getProperty("outA1")).to((IProcessInOutPut)pB1.getProperty("inB1"));
+        mapper.link((IProcessInOutPut)pB1.getProperty("outB1")).to((IProcessInOutPut)pC.getProperty("inC2"));
         mapper.link((IProcessInOutPut)pA.getProperty("outA1")).to((IProcessInOutPut)pC.getProperty("inC1"));
 
         LinkedHashMap<String, Object> dataMap = new LinkedHashMap<>();
@@ -148,66 +199,7 @@ public class ProcessMapperTest {
      *  --> -----  |--> ----
      */
     @Test
-    void testMapping2(){
-
-        LinkedHashMap<String, Object> pAInputMap = new LinkedHashMap<>();
-        pAInputMap.put("inA1", String.class);
-        pAInputMap.put("inA2", String.class);
-        LinkedHashMap<String, Object> pAOutputMap = new LinkedHashMap<>();
-        pAOutputMap.put("outA1", String.class);
-        Process pA1 = (Process)processManager.factory("map5").create("pA", pAInputMap, pAOutputMap, new Closure(this) {
-            public int getMaximumNumberOfParameters() {
-                return 2;
-            }
-            @Override
-            public Object call(Object... arguments) {
-                Map<String, Object> map = new HashMap<>();
-                map.put("outA1", arguments[0].toString() + arguments[1].toString());
-                return map;
-            }
-        });
-
-        Process pA2 = (Process)processManager.factory("map5").create("pA", pAInputMap, pAOutputMap, new Closure(this) {
-            public int getMaximumNumberOfParameters() {
-                return 2;
-            }
-            @Override
-            public Object call(Object... arguments) {
-                Map<String, Object> map = new HashMap<>();
-                map.put("outA1", arguments[0].toString() + arguments[1].toString());
-                return map;
-            }
-        });
-
-
-        LinkedHashMap<String, Object> pBInputMap = new LinkedHashMap<>();
-        pBInputMap.put("inB1", String.class);
-        pBInputMap.put("inB2", String.class);
-        LinkedHashMap<String, Object> pBOutputMap = new LinkedHashMap<>();
-        pBOutputMap.put("outB1", String.class);
-        Process pB1 = (Process)processManager.factory("map5").create("pB", pBInputMap, pBOutputMap, new Closure(this) {
-            public int getMaximumNumberOfParameters() {
-                return 2;
-            }
-            @Override
-            public Object call(Object... arguments) {
-                Map<String, Object> map = new HashMap<>();
-                map.put("outB1", arguments[1].toString() + " or " + arguments[0].toString());
-                return map;
-            }
-        });
-
-        Process pB2 = (Process)processManager.factory("map5").create("pB", pBInputMap, pBOutputMap, new Closure(this) {
-            public int getMaximumNumberOfParameters() {
-                return 2;
-            }
-            @Override
-            public Object call(Object... arguments) {
-                Map<String, Object> map = new HashMap<>();
-                map.put("outB1", arguments[1].toString() + " or " + arguments[0].toString());
-                return map;
-            }
-        });
+    public void testMapping2(){
 
         IProcessMapper mapper = new ProcessMapper();
 

--- a/process-manager/src/test/java/org/orbisgis/processmanager/ProcessMapperTest.java
+++ b/process-manager/src/test/java/org/orbisgis/processmanager/ProcessMapperTest.java
@@ -57,6 +57,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class ProcessMapperTest {
 
+    private static final IProcessManager processManager = ProcessManager.getProcessManager();
+
     private static Process pA1;
     private static Process pA2;
     private static Process pB1;
@@ -124,8 +126,6 @@ public class ProcessMapperTest {
         });
     }
 
-    private static final IProcessManager processManager = ProcessManager.getProcessManager();
-
     /**
      *   --> ----
      *      | pB | -----> ---- -->
@@ -138,7 +138,7 @@ public class ProcessMapperTest {
      *      ----
      */
     @Test
-    void testMapping1(){
+    public void testMapping1(){
 
         LinkedHashMap<String, Object> pAInputMap = new LinkedHashMap<>();
         pAInputMap.put("inA1", String.class);
@@ -184,8 +184,8 @@ public class ProcessMapperTest {
         dataMap.put("inA1", "a");
         dataMap.put("inB2", "b");
         assertTrue(mapper.execute(dataMap));
-        assertEquals("AbA", mapper.getResults().get("outC1"));
-        assertEquals("bAA", mapper.getResults().get("outC2"));
+        assertEquals("Ab or A", mapper.getResults().get("outC1"));
+        assertEquals("b or AA", mapper.getResults().get("outC2"));
     }
 
 

--- a/process-manager/src/test/java/org/orbisgis/processmanager/ProcessMapperTest.java
+++ b/process-manager/src/test/java/org/orbisgis/processmanager/ProcessMapperTest.java
@@ -1,0 +1,264 @@
+/*
+ * Bundle ProcessManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * ProcessManager is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * ProcessManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * ProcessManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * ProcessManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.processmanager;
+
+import groovy.lang.Closure;
+import org.junit.jupiter.api.Test;
+import org.orbisgis.processmanagerapi.IProcessInOutPut;
+import org.orbisgis.processmanagerapi.IProcessManager;
+import org.orbisgis.processmanagerapi.IProcessMapper;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class dedicated to {@link ProcessMapper} interface.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public class ProcessMapperTest {
+
+    private static final IProcessManager processManager = ProcessManager.getProcessManager();
+
+    /**
+     *   --> ----
+     *      | pB | -----> ---- -->
+     *  |--> ----        | pC |
+     *  |            |--> ---- -->
+     *  |------------|
+     *               |
+     *  --> ----     |
+     *     | pA | ---|
+     *      ----
+     */
+    @Test
+    void testMapping1(){
+
+        LinkedHashMap<String, Object> pAInputMap = new LinkedHashMap<>();
+        pAInputMap.put("inA1", String.class);
+        LinkedHashMap<String, Object> pAOutputMap = new LinkedHashMap<>();
+        pAOutputMap.put("outA1", String.class);
+        Process pA = (Process)processManager.factory("map2").create("pA", pAInputMap, pAOutputMap, new Closure(this) {
+            public int getMaximumNumberOfParameters() {
+                return 1;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outA1", arguments[0].toString().toUpperCase());
+                return map;
+            }
+        });
+
+        LinkedHashMap<String, Object> pBInputMap = new LinkedHashMap<>();
+        pBInputMap.put("inB1", String.class);
+        pBInputMap.put("inB2", String.class);
+        LinkedHashMap<String, Object> pBOutputMap = new LinkedHashMap<>();
+        pBOutputMap.put("outB1", String.class);
+        Process pB = (Process)processManager.factory("map2").create("pB", pBInputMap, pBOutputMap, new Closure(this) {
+            public int getMaximumNumberOfParameters() {
+                return 2;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outB1", arguments[1].toString() + arguments[0].toString());
+                return map;
+            }
+        });
+
+        LinkedHashMap<String, Object> pCInputMap = new LinkedHashMap<>();
+        pCInputMap.put("inC1", String.class);
+        pCInputMap.put("inC2", String.class);
+        LinkedHashMap<String, Object> pCOutputMap = new LinkedHashMap<>();
+        pCOutputMap.put("outC1", String.class);
+        pCOutputMap.put("outC2", String.class);
+        Process pC = (Process)processManager.factory("map2").create("pC", pCInputMap, pCOutputMap, new Closure(this) {
+            public int getMaximumNumberOfParameters() {
+                return 2;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outC1", arguments[0].toString() + arguments[1].toString());
+                map.put("outC2", arguments[1].toString() + arguments[0].toString());
+                return map;
+            }
+        });
+
+        IProcessMapper mapper = new ProcessMapper();
+        mapper.link((IProcessInOutPut)pA.getProperty("outA1")).to((IProcessInOutPut)pB.getProperty("inB1"));
+        mapper.link((IProcessInOutPut)pB.getProperty("outB1")).to((IProcessInOutPut)pC.getProperty("inC2"));
+        mapper.link((IProcessInOutPut)pA.getProperty("outA1")).to((IProcessInOutPut)pC.getProperty("inC1"));
+
+        LinkedHashMap<String, Object> dataMap = new LinkedHashMap<>();
+        dataMap.put("inA1", "a");
+        dataMap.put("inB2", "b");
+        assertTrue(mapper.execute(dataMap));
+        assertEquals("AbA", mapper.getResults().get("outC1"));
+        assertEquals("bAA", mapper.getResults().get("outC2"));
+    }
+
+
+    /**
+     *  --> -----  |--> ----
+     *     |  pA |-|   | pB |--->
+     *  --> -----  |--> ----
+     *
+     *  --> -----  |--> ----
+     *     |  pA |-|   | pB |--->
+     *  --> -----  |--> ----
+     */
+    @Test
+    void testMapping2(){
+
+        LinkedHashMap<String, Object> pAInputMap = new LinkedHashMap<>();
+        pAInputMap.put("inA1", String.class);
+        pAInputMap.put("inA2", String.class);
+        LinkedHashMap<String, Object> pAOutputMap = new LinkedHashMap<>();
+        pAOutputMap.put("outA1", String.class);
+        Process pA1 = (Process)processManager.factory("map5").create("pA", pAInputMap, pAOutputMap, new Closure(this) {
+            public int getMaximumNumberOfParameters() {
+                return 2;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outA1", arguments[0].toString() + arguments[1].toString());
+                return map;
+            }
+        });
+
+        Process pA2 = (Process)processManager.factory("map5").create("pA", pAInputMap, pAOutputMap, new Closure(this) {
+            public int getMaximumNumberOfParameters() {
+                return 2;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outA1", arguments[0].toString() + arguments[1].toString());
+                return map;
+            }
+        });
+
+
+        LinkedHashMap<String, Object> pBInputMap = new LinkedHashMap<>();
+        pBInputMap.put("inB1", String.class);
+        pBInputMap.put("inB2", String.class);
+        LinkedHashMap<String, Object> pBOutputMap = new LinkedHashMap<>();
+        pBOutputMap.put("outB1", String.class);
+        Process pB1 = (Process)processManager.factory("map5").create("pB", pBInputMap, pBOutputMap, new Closure(this) {
+            public int getMaximumNumberOfParameters() {
+                return 2;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outB1", arguments[1].toString() + " or " + arguments[0].toString());
+                return map;
+            }
+        });
+
+        Process pB2 = (Process)processManager.factory("map5").create("pB", pBInputMap, pBOutputMap, new Closure(this) {
+            public int getMaximumNumberOfParameters() {
+                return 2;
+            }
+            @Override
+            public Object call(Object... arguments) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("outB1", arguments[1].toString() + " or " + arguments[0].toString());
+                return map;
+            }
+        });
+
+        IProcessMapper mapper = new ProcessMapper();
+
+        mapper.link((IProcessInOutPut)pA1.getProperty("outA1")).to((IProcessInOutPut)pB1.getProperty("inB1"));
+        mapper.link((IProcessInOutPut)pA1.getProperty("outA1")).to((IProcessInOutPut)pB1.getProperty("inB2"));
+        mapper.link((IProcessInOutPut)pA2.getProperty("outA1")).to((IProcessInOutPut)pB2.getProperty("inB1"), (IProcessInOutPut)pB2.getProperty("inB2"));
+
+        mapper.link((IProcessInOutPut)pA1.getProperty("outA1")).to("interPA1OutA1");
+        mapper.link((IProcessInOutPut)pA2.getProperty("outA1")).to("interPA2OutA1");
+
+        mapper.link((IProcessInOutPut)pA1.getProperty("inA1"), (IProcessInOutPut)pA2.getProperty("inA1")).to("commonInput");
+        mapper.link((IProcessInOutPut)pA1.getProperty("inA2")).to("inputD");
+        mapper.link((IProcessInOutPut)pA2.getProperty("inA2")).to("inputK");
+
+        mapper.link((IProcessInOutPut)pB1.getProperty("outB1")).to("outD");
+        mapper.link((IProcessInOutPut)pB2.getProperty("outB1")).to("outK");
+
+        LinkedHashMap<String, Object> dataMap = new LinkedHashMap<>();
+        dataMap.put("inputD", "D");
+        dataMap.put("inputK", "K");
+        dataMap.put("commonInput", "common");
+        assertTrue(mapper.execute(dataMap));
+
+        assertEquals(5, mapper.getInputs().size());
+        assertTrue(mapper.getInputs().containsKey("inA1"));
+        assertEquals(String.class, mapper.getInputs().get("inA1"));
+        assertTrue(mapper.getInputs().containsKey("inA2"));
+        assertEquals(String.class, mapper.getInputs().get("inA2"));
+        assertTrue(mapper.getInputs().containsKey("inputD"));
+        assertEquals(String.class, mapper.getInputs().get("inputD"));
+        assertTrue(mapper.getInputs().containsKey("inputK"));
+        assertEquals(String.class, mapper.getInputs().get("inputK"));
+        assertTrue(mapper.getInputs().containsKey("commonInput"));
+        assertEquals(String.class, mapper.getInputs().get("commonInput"));
+
+        assertEquals(5, mapper.getOutputs().size());
+        assertTrue(mapper.getOutputs().containsKey("interPA2OutA1"));
+        assertEquals(String.class, mapper.getOutputs().get("interPA2OutA1"));
+        assertTrue(mapper.getOutputs().containsKey("interPA1OutA1"));
+        assertEquals(String.class, mapper.getOutputs().get("interPA1OutA1"));
+        assertTrue(mapper.getOutputs().containsKey("outB1"));
+        assertEquals(String.class, mapper.getOutputs().get("outB1"));
+        assertTrue(mapper.getOutputs().containsKey("outD"));
+        assertEquals(String.class, mapper.getOutputs().get("outD"));
+        assertTrue(mapper.getOutputs().containsKey("outK"));
+        assertEquals(String.class, mapper.getOutputs().get("outK"));
+
+        assertFalse(mapper.getResults().containsKey("outB1"));
+        assertEquals("commonD or commonD", mapper.getResults().get("outD"));
+        assertEquals("commonK or commonK", mapper.getResults().get("outK"));
+        assertEquals("commonK", mapper.getResults().get("interPA2OutA1"));
+        assertEquals("commonD", mapper.getResults().get("interPA1OutA1"));
+    }
+}


### PR DESCRIPTION
The syntax is now : `mapper.link(input/output[])…to(input/output[] or String)`.  Linked to #92 and #89 
As example : 
``` groovy
        def pA1 = ...
        def pA2 = ...
        def pB1 = ...
        def pB2 = ...
        def mapper = new ProcessMapper()

        mapper.link(pA1.outA1).to(pB1.inB1)
        mapper.link(pA1.outA1).to(pB1.inB2)
        mapper.link(pA2.outA1).to(pB2.inB1, pB2.inB2)

        mapper.link(pA1.outA1).to("interPA1OutA1")
        mapper.link(pA2.outA1).to("interPA2OutA1")

        mapper.link(pA1.inA1, pA2.inA1).to("commonInput")
        mapper.link(pA1.inA2).to("inputD")
        mapper.link(pA2.inA2).to("inputK")

        mapper.link(pB1.outB1).to("outD")
        mapper.link(pB2.outB1).to("outK")

        mapper.execute([inputD: "D", inputK: "K", commonInput: "common"])

        assert "commonD or commonD" == mapper.getResults().outD
        assert "commonK or commonK" == mapper.getResults().outK
        assert "commonK" == mapper.getResults().interPA2OutA1
        assert "commonD" == mapper.getResults().interPA1OutA1
```