### PR TITLE
Return null.

### DIFF
--- a/process-manager/src/main/java/org/orbisgis/processmanager/Process.java
+++ b/process-manager/src/main/java/org/orbisgis/processmanager/Process.java
@@ -239,7 +239,12 @@ public class Process implements IProcess, GroovyObject {
             LOGGER.error("Error while executing the process.\n"+e.getLocalizedMessage());
             return false;
         }
-        return checkResults(result);
+        if(result == null && outputs.size() != 0){
+            return false;
+        }
+        else {
+            return checkResults(result);
+        }
     }
 
     /**

--- a/process-manager/src/test/groovy/org/orbisgis/processmanager/TestProcess.groovy
+++ b/process-manager/src/test/groovy/org/orbisgis/processmanager/TestProcess.groovy
@@ -116,6 +116,16 @@ class TestProcess {
     }
 
     @Test
+    void testNullResult(){
+        def process = processManager.create()
+                .title("simple process")
+                .run({ return })
+                .process
+        assertTrue process()
+        assertTrue process.getResults().keySet().contains("result")
+    }
+
+    @Test
     void testSimpleProcess(){
         def process = processManager.create()
                 .title("simple process")

--- a/process-manager/src/test/java/org/orbisgis/processmanager/ProcessTest.java
+++ b/process-manager/src/test/java/org/orbisgis/processmanager/ProcessTest.java
@@ -108,6 +108,22 @@ public class ProcessTest {
     }
 
     @Test
+    void testNullResult(){
+        Closure cl = new Closure(null) {
+            @Override
+            public Object call() {
+                return null;
+            }
+        };
+
+        LinkedHashMap<String, Object> outputs = new LinkedHashMap<>();
+        outputs.put("out1", Output.call().setType(int.class));
+
+        assertFalse(new Process("title", "description", new String[]{"test", "process"}, new LinkedHashMap<>(),
+                outputs, "1.0.0", cl).execute(new LinkedHashMap<>()));
+    }
+
+    @Test
     void testProcessProperties(){
         assertNull(miniProcess.getTitle());
         assertNull(miniProcess.getDescription());


### PR DESCRIPTION
Make process execution return false if the closure execution return null and there is at least one output.