### PR TITLE
Fixes and column filter

### DIFF
--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IJdbcTable.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dataset/IJdbcTable.java
@@ -37,6 +37,7 @@
 package org.orbisgis.datamanagerapi.dataset;
 
 import groovy.lang.Closure;
+import org.orbisgis.datamanagerapi.dsl.IColumnsBuilder;
 import org.orbisgis.datamanagerapi.dsl.IWhereBuilderOrOptionBuilder;
 
 import java.sql.ResultSet;
@@ -48,7 +49,7 @@ import java.util.Iterator;
  * Extension of the {@link ITable} specially dedicated to the JDBC databases thanks to the extension of the
  * {@link ResultSet} interface. It also extends the {@link IWhereBuilderOrOptionBuilder} for the SQL requesting
  */
-public interface IJdbcTable extends ITable, ResultSet, IWhereBuilderOrOptionBuilder {
+public interface IJdbcTable extends ITable, ResultSet, IWhereBuilderOrOptionBuilder, IColumnsBuilder {
 
     /** {@link String} name of the metadata property */
     String META_PROPERTY = "meta";

--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/datasource/IJdbcDataSource.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/datasource/IJdbcDataSource.java
@@ -63,7 +63,7 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
 
     /**
      * Return the {@link ITable} contained by the database with the given name. If the table contains a geometric
-     * field, return a ISpatialTable.
+     * field, return a {@link ISpatialTable}.
      *
      * @param tableName Name of the requested table.
      *
@@ -108,7 +108,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * Load a file into the database.
      *
      * @param filePath Path of the file.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(String filePath);
 
@@ -117,7 +118,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      *
      * @param filePath Path of the file.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(String filePath, boolean delete);
 
@@ -126,7 +128,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      *
      * @param filePath Path of the file.
      * @param tableName Name of the table.
-     * @return 
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(String filePath, String tableName);
 
@@ -136,7 +139,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param filePath Path of the file.
      * @param tableName Name of the table.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(String filePath, String tableName, boolean delete);
 
@@ -147,7 +151,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param tableName Name of the table
      * @param encoding Encoding of the loaded file.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(String filePath, String tableName, String encoding, boolean delete);
 
@@ -155,7 +160,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * Load a file into the database.
      *
      * @param url {@link URL} of the file.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(URL url);
 
@@ -164,7 +170,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      *
      * @param url {@link URL} of the file.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(URL url, boolean delete);
 
@@ -173,7 +180,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      *
      * @param url {@link URL} of the file.
      * @param tableName Name of the table.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(URL url, String tableName);
 
@@ -183,7 +191,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param url {@link URL} of the file.
      * @param tableName Name of the table.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(URL url, String tableName, boolean delete);
 
@@ -194,7 +203,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param tableName Name of the table
      * @param encoding Encoding of the loaded file.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(URL url, String tableName, String encoding, boolean delete);
 
@@ -202,7 +212,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * Load a file into the database.
      *
      * @param uri {@link URI} of the file.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(URI uri);
 
@@ -211,7 +222,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      *
      * @param uri {@link URI} of the file.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(URI uri, boolean delete);
 
@@ -220,7 +232,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      *
      * @param uri {@link URI} of the file.
      * @param tableName Name of the table.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(URI uri, String tableName);
 
@@ -230,7 +243,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param uri {@link URI} of the file.
      * @param tableName Name of the table.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(URI uri, String tableName, boolean delete);
 
@@ -241,7 +255,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param tableName Name of the table
      * @param encoding Encoding of the loaded file.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(URI uri, String tableName, String encoding, boolean delete);
 
@@ -249,7 +264,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * Load a file into the database.
      *
      * @param file {@link File}.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(File file);
 
@@ -258,7 +274,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      *
      * @param file {@link File}.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(File file, boolean delete);
 
@@ -267,7 +284,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      *
      * @param file {@link File}.
      * @param tableName Name of the table.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(File file, String tableName);
 
@@ -277,7 +295,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param file {@link File}.
      * @param tableName Name of the table.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(File file, String tableName, boolean delete);
 
@@ -288,7 +307,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param tableName Name of the table
      * @param encoding Encoding of the loaded file.
      * @param delete True to delete the table if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(File file, String tableName, String encoding, boolean delete);
 
@@ -297,7 +317,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      *
      * @param properties Properties used to connect to the database.
      * @param inputTableName Name of the table to import.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(Map<String, String> properties, String inputTableName);
 
@@ -308,7 +329,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param properties Properties used to connect to the database.
      * @param inputTableName Name of the table to import.
      * @param outputTableName Name of the imported table in the database.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(Map<String, String> properties, String inputTableName, String outputTableName);
 
@@ -318,7 +340,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param properties Properties used to connect to the database.
      * @param inputTableName Name of the table to import.
      * @param delete True to delete the outputTableName if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(Map<String, String> properties, String inputTableName, boolean delete);
 
@@ -329,7 +352,8 @@ public interface IJdbcDataSource extends IDataSource, GroovyObject {
      * @param inputTableName Name of the table to import.
      * @param outputTableName Name of the imported table in the database.
      * @param delete True to delete the outputTableName if exists, false otherwise.
-     * @return a ITable
+     *
+     * @return The {@link ITable} containing the loaded data.
      */
     ITable load(Map<String, String> properties, String inputTableName, String outputTableName, boolean delete);
 

--- a/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IColumnsBuilder.java
+++ b/data-manager-api/src/main/java/org/orbisgis/datamanagerapi/dsl/IColumnsBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Bundle DataManager API is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * DataManager API  is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2019 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * DataManager API  is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * DataManager API  is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * DataManager API. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datamanagerapi.dsl;
+
+import org.orbisgis.datamanagerapi.dataset.ITable;
+
+/**
+ * Interface defining methods for the SQL 'select ... from' building. The request construction can be continued thanks to the
+ * {@link IWhereBuilderOrOptionBuilder} or its result can be get calling 'eachRow' to iterate on the resultSet or
+ * 'as ITable' to get the {@link ITable} object
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019)
+ */
+public interface IColumnsBuilder {
+
+    /**
+     * Indicates the columns use for the selection.
+     *
+     * @param columns Array of the columns use for the selection.
+     *
+     * @return {@link IWhereBuilderOrOptionBuilder} instance to continue building.
+     */
+    IWhereBuilderOrOptionBuilder columns(String... columns);
+}

--- a/data-manager-api/src/test/java/org/orbisgis/datamanagerapi/dataset/IJdbcTableTest.java
+++ b/data-manager-api/src/test/java/org/orbisgis/datamanagerapi/dataset/IJdbcTableTest.java
@@ -40,6 +40,7 @@ import groovy.lang.Closure;
 import org.junit.jupiter.api.Test;
 import org.orbisgis.datamanagerapi.dsl.IConditionOrOptionBuilder;
 import org.orbisgis.datamanagerapi.dsl.IOptionBuilder;
+import org.orbisgis.datamanagerapi.dsl.IWhereBuilderOrOptionBuilder;
 
 import javax.sql.rowset.RowSetMetaDataImpl;
 import java.io.InputStream;
@@ -454,5 +455,6 @@ public class IJdbcTableTest {
         @Override public Object asType(Class clazz) {return null;}
         @Override public ITable getTable() {return null;}
         @Override public ISpatialTable getSpatialTable() {return null;}
+        @Override public IWhereBuilderOrOptionBuilder columns(String... columns) {return null;}
     }
 }

--- a/data-manager/src/main/java/org/orbisgis/datamanager/JdbcTable.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/JdbcTable.java
@@ -140,10 +140,11 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
      *
      * @return The {@link ResultSet} with a limit.
      */
-    protected ResultSet getResultSetLimit(int limit){
-        if(limit < 0){
+    private ResultSet getResultSetLimit(int limit){
+        int _limit = limit;
+        if(_limit < 0){
             LOGGER.warn("The ResultSet limit should not be under 0. Set it to 0.");
-            limit = 0;
+            _limit = 0;
         }
         ResultSet resultSet;
         try {
@@ -151,7 +152,7 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
                 resultSet = getResultSet();
             }
             else {
-                resultSet = jdbcDataSource.getConnection().createStatement().executeQuery(getBaseQuery() + " LIMIT " + limit);
+                resultSet = jdbcDataSource.getConnection().createStatement().executeQuery(getBaseQuery() + " LIMIT " + _limit);
             }
         } catch (SQLException e) {
             LOGGER.error("Unable to execute the query '"+getBaseQuery()+"'.\n"+e.getLocalizedMessage());

--- a/data-manager/src/main/java/org/orbisgis/datamanager/JdbcTable.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/JdbcTable.java
@@ -53,6 +53,7 @@ import org.orbisgis.datamanager.io.IOMethods;
 import org.orbisgis.datamanagerapi.dataset.*;
 import org.orbisgis.datamanagerapi.dsl.IConditionOrOptionBuilder;
 import org.orbisgis.datamanagerapi.dsl.IOptionBuilder;
+import org.orbisgis.datamanagerapi.dsl.IWhereBuilderOrOptionBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +62,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.orbisgis.commons.printer.ICustomPrinter.CellPosition.*;
 
@@ -138,18 +140,24 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
     }
 
     /**
-     * Return the {@link ResultSet} with a limit set to 1.
+     * Return the {@link ResultSet} with a limit.
      *
-     * @return The {@link ResultSet} with a limit set to 1.
+     * @param limit Limit of the result set.
+     *
+     * @return The {@link ResultSet} with a limit.
      */
-    protected ResultSet getResultSetLimit1(){
+    protected ResultSet getResultSetLimit(int limit){
+        if(limit < 0){
+            LOGGER.warn("The ResultSet limit should not be under 0. Set it to 0.");
+            limit = 0;
+        }
         ResultSet resultSet;
         try {
             if(getBaseQuery().contains(" LIMIT ")){
                 resultSet = getResultSet();
             }
             else {
-                resultSet = jdbcDataSource.getConnection().createStatement().executeQuery(getBaseQuery() + " LIMIT 1");
+                resultSet = jdbcDataSource.getConnection().createStatement().executeQuery(getBaseQuery() + " LIMIT " + limit);
             }
         } catch (SQLException e) {
             LOGGER.error("Unable to execute the query '"+getBaseQuery()+"'.\n"+e.getLocalizedMessage());
@@ -167,7 +175,7 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
     @Override
     public ResultSetMetaData getMetaData(){
         try {
-            ResultSet rs = getResultSetLimit1();
+            ResultSet rs = getResultSetLimit(0);
             if(rs == null){
                 LOGGER.error("The ResultSet is null.");
             }
@@ -237,7 +245,11 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
     @Override
     public Collection<String> getColumnNames() {
         try {
-            return JDBCUtilities.getFieldNames(getResultSetLimit1().getMetaData());
+            return JDBCUtilities
+                    .getFieldNames(getResultSetLimit(0).getMetaData())
+                    .stream()
+                    .map(this::formatColumnName)
+                    .collect(Collectors.toCollection(ArrayList::new));
         } catch (SQLException e) {
             LOGGER.error("Unable to get the collection of columns names");
             return null;
@@ -371,6 +383,15 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
         return "SELECT * FROM " + getTableLocation().getTable().toUpperCase();
     }
 
+    private String getQuery(String ... columns){
+        return "SELECT " + String.join(", ", columns) + " FROM " + getTableLocation().getTable().toUpperCase();
+    }
+
+    @Override
+    public IWhereBuilderOrOptionBuilder columns(String... columns){
+        return new WhereBuilder(getQuery(columns), getJdbcDataSource());
+    }
+
     @Override
     public IConditionOrOptionBuilder where(String condition) {
         return new WhereBuilder(getQuery(), getJdbcDataSource()).where(condition);
@@ -419,7 +440,7 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
     @Override
     public List<Object> getFirstRow(){
         List<Object> list = new ArrayList<>();
-        ResultSet rs = getResultSetLimit1();
+        ResultSet rs = getResultSetLimit(1);
         try {
             if(rs.next()){
                 for(int i=1; i<=getColumnCount(); i++){
@@ -456,10 +477,10 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
         Collection<String> columns = getColumnNames();
         if(columns!= null &&
                 (columns.contains(propertyName.toLowerCase()) || columns.contains(propertyName.toUpperCase()))
-                || "id".equals(propertyName)) {
+                || "id".equalsIgnoreCase(propertyName)) {
             try {
-                if(isBeforeFirst()){
-                    return new JdbcColumn(propertyName, this.getName(), getJdbcDataSource());
+                if(isBeforeFirst() || (this.getRow() == 0 && this.getRowCount() == 0)){
+                    return new JdbcColumn(formatColumnName(propertyName), this.getName(), getJdbcDataSource());
                 }
                 return getObject(propertyName);
             } catch (SQLException e) {
@@ -530,5 +551,16 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
             return null;
         }
         return null;
+    }
+
+    /**
+     * Format the column according to the DB type.
+     *
+     * @param column Columne name to format.
+     *
+     * @return The formatted column name.
+     */
+    private String formatColumnName(String column){
+        return getDbType()==DataBaseType.H2GIS ? column.toUpperCase() : column.toLowerCase();
     }
 }

--- a/data-manager/src/main/java/org/orbisgis/datamanager/dsl/ConditionOrOptionBuilder.java
+++ b/data-manager/src/main/java/org/orbisgis/datamanager/dsl/ConditionOrOptionBuilder.java
@@ -40,7 +40,7 @@ import org.orbisgis.datamanager.JdbcDataSource;
 import org.orbisgis.datamanagerapi.dsl.IConditionOrOptionBuilder;
 
 /**
- * Implementation of IConditionOrOptionBuilder
+ * Implementation of {@link IConditionOrOptionBuilder}
  *
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS 2019)


### PR DESCRIPTION
Fix the issue #161.
The JdbcTable columns can now be filtered using `table.columns("col1", "col23", "col14")` and return a IBuilder so it cn be followed by `where(...)`, `groupby(...)` ... or converted to a ITable with `as ITable`