### PR TITLE
Fix Groovy class overlapping.

### DIFF
--- a/data-manager/api/pom.xml
+++ b/data-manager/api/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
-            <version>1.15.1</version>
         </dependency>
 
         <dependency>

--- a/data-manager/dataframe/src/main/java/org/orbisgis/orbisdata/datamanager/dataframe/DataFrame.java
+++ b/data-manager/dataframe/src/main/java/org/orbisgis/orbisdata/datamanager/dataframe/DataFrame.java
@@ -383,17 +383,17 @@ public class DataFrame implements smile.data.DataFrame, ITable<BaseVector> {
     }
 
     /**
-     * Convert a {@link ITable} into an OrbisData {@link DataFrame}.
+     * Convert a {@link ResultSet} into an OrbisData {@link DataFrame}.
      *
-     * @param table {@link ITable}.
+     * @param rs {@link ResultSet}.
      *
      * @return OrbisData {@link DataFrame}.
      *
-     * @throws SQLException Exception thrown in case or error while manipulation SQL base {@link ITable}.
+     * @throws SQLException Exception thrown in case or error while manipulation SQL base {@link ResultSet}.
      */
-    public static DataFrame of(ITable table) throws SQLException {
-        if(table instanceof IJdbcTable){
-            IJdbcTable jdbcTable = (IJdbcTable)table;
+    public static DataFrame of(ResultSet rs) throws SQLException {
+        if(rs instanceof IJdbcTable){
+            IJdbcTable jdbcTable = (IJdbcTable)rs;
             StructType schema = getStructure(jdbcTable);
             ArrayList<Tuple> rows = new ArrayList<>();
             while(jdbcTable.next()) {
@@ -401,8 +401,9 @@ public class DataFrame implements smile.data.DataFrame, ITable<BaseVector> {
             }
             return of(smile.data.DataFrame.of(rows));
         }
-        LOGGER.error("The class '" + table.getClass().getCanonicalName() + "' is not supported.");
-        return null;
+        else{
+            return of(smile.data.DataFrame.of(rs));
+        }
     }
 
     private static StructType getStructure(IJdbcTable table){

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/h2gis/H2GIS.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/h2gis/H2GIS.java
@@ -45,6 +45,8 @@ import org.h2gis.utilities.SFSUtilities;
 import org.h2gis.utilities.wrapper.ConnectionWrapper;
 import org.h2gis.utilities.wrapper.StatementWrapper;
 import org.orbisgis.orbisdata.datamanager.jdbc.JdbcDataSource;
+import org.orbisgis.orbisdata.datamanager.jdbc.JdbcSpatialTable;
+import org.orbisgis.orbisdata.datamanager.jdbc.JdbcTable;
 import org.orbisgis.orbisdata.datamanager.jdbc.TableLocation;
 import org.orbisgis.orbisdata.datamanager.api.dataset.DataBaseType;
 import org.orbisgis.orbisdata.datamanager.api.dataset.ISpatialTable;
@@ -194,7 +196,7 @@ public class H2GIS extends JdbcDataSource {
     }
 
     @Override
-    public ITable getTable(String tableName) {
+    public JdbcTable getTable(String tableName) {
         String name = TableLocation.parse(tableName, getDataBaseType().equals(DataBaseType.H2GIS)).toString( getDataBaseType().equals(DataBaseType.H2GIS));
         try {
             if(!JDBCUtilities.tableExists(connectionWrapper,name)){
@@ -224,10 +226,10 @@ public class H2GIS extends JdbcDataSource {
     }
 
     @Override
-    public ISpatialTable getSpatialTable(String tableName) {
+    public JdbcSpatialTable getSpatialTable(String tableName) {
         ITable table = getTable(tableName);
         if(table instanceof ISpatialTable){
-            return (ISpatialTable) table;
+            return (JdbcSpatialTable) table;
         }
         else {
             LOGGER.error("The table '" + table.getName() + "' is not a spatial table.");


### PR DESCRIPTION
Avoid Groovy overlapping between ResultSet and ITable for DataFrame.of() method.

Linked to the issue #184 