### PR TITLE
Add reload() methods which update the source of a IDataSet.

### DIFF
--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dataset/IDataSet.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dataset/IDataSet.java
@@ -95,4 +95,11 @@ public interface IDataSet<T> extends Iterable<T> {
      */
     @NotNull
     ISummary getSummary();
+
+    /**
+     * Reload the source of the {@link IDataSet}.
+     *
+     * @return true if the reload has been done successfully, false otherwise.
+     */
+    boolean reload();
 }

--- a/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/IJdbcTableTest.java
+++ b/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/IJdbcTableTest.java
@@ -299,6 +299,11 @@ public class IJdbcTableTest {
         }
 
         @Override
+        public boolean reload() {
+            return false;
+        }
+
+        @Override
         public boolean next() throws SQLException {
             if (!sqlException) {
                 return rowIndex++ < data.length;

--- a/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/ITableTest.java
+++ b/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/ITableTest.java
@@ -556,6 +556,11 @@ public class ITableTest {
         }
 
         @Override
+        public boolean reload() {
+            return false;
+        }
+
+        @Override
         public Iterator<Object> iterator() {
             return new DummyIterator();
         }

--- a/data-manager/dataframe/src/main/java/org/orbisgis/orbisdata/datamanager/dataframe/DataFrame.java
+++ b/data-manager/dataframe/src/main/java/org/orbisgis/orbisdata/datamanager/dataframe/DataFrame.java
@@ -263,6 +263,11 @@ public class DataFrame implements smile.data.DataFrame, ITable<BaseVector> {
     }
 
     @Override
+    public boolean reload() {
+        return false;
+    }
+
+    @Override
     @NotNull
     public Summary summary() {
         return new Summary(getInternalDataFrame().summary());

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTable.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTable.java
@@ -110,6 +110,7 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
     /**
      * Cached resultSet
      */
+    @Nullable
     protected ResultSet resultSet;
 
     /**
@@ -139,6 +140,12 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
     @NotNull
     protected String getBaseQuery() {
         return baseQuery;
+    }
+
+    @Override
+    public boolean reload(){
+        resultSet = null;
+        return getResultSet() != null;
     }
 
     @Override


### PR DESCRIPTION
Add reload() methods which update the source of a IDataSet.
For a JdbcTable, it reload the wrapped ResultSet.