### PR TITLE
Move methods in parent classes.

### DIFF
--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dataset/IDataSet.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dataset/IDataSet.java
@@ -102,4 +102,13 @@ public interface IDataSet<T> extends Iterable<T> {
      * @return true if the reload has been done successfully, false otherwise.
      */
     boolean reload();
+
+    /**
+     * Returns a {@link IDataSet} with the given filter applied.
+     * The filter syntax depends on the {@link IDataSet} type.
+     *
+     * @param filter Filtes to apply.
+     * @return A filtered {@link IDataSet}
+     */
+    IDataSet<?> filter(String filter);
 }

--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dataset/ITable.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dataset/ITable.java
@@ -42,6 +42,7 @@ import org.orbisgis.commons.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.sql.Date;
+import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Collection;
@@ -155,11 +156,46 @@ public interface ITable<T> extends IMatrix<T> {
     int getRow() throws Exception;
 
     /**
-     * Go to the next row.
+     * Goes to the next row.
      *
      * @return True if the next row has been reach, false otherwise.
      */
     boolean next() throws Exception;
+
+    /**
+     * Goes to the previous row.
+     *
+     * @return True if the previous row has been reach, false otherwise.
+     */
+    boolean previous() throws Exception;
+
+    /**
+     * Goes to the first row.
+     *
+     * @return True if the first row has been reach, false otherwise.
+     */
+    boolean first() throws Exception;
+
+    /**
+     * Goes to the last row.
+     *
+     * @return True if the last row has been reach, false otherwise.
+     */
+    boolean last() throws Exception;
+
+    /**
+     * Returns true if the current row position is the first row.
+     *
+     * @return True if the current row position is the first row.
+     */
+    boolean isFirst() throws Exception;
+
+    /**
+     * Returns true if the current row position is the last row.
+     *
+     * @return True if the current row position is the last row.
+     */
+    boolean isLast() throws Exception;
 
     /**
      * Return a {@link Collection} of all the unique values of the {@link ITable}. This method can take a lot of time and

--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/datasource/IDataSource.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/datasource/IDataSource.java
@@ -39,6 +39,13 @@ package org.orbisgis.orbisdata.datamanager.api.datasource;
 import org.orbisgis.commons.annotations.NotNull;
 import org.orbisgis.commons.annotations.Nullable;
 import org.orbisgis.orbisdata.datamanager.api.dataset.IDataSet;
+import org.orbisgis.orbisdata.datamanager.api.dataset.IDataSet;
+import org.orbisgis.orbisdata.datamanager.api.dataset.IDataSet;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.util.Map;
 
 /**
  * Raw source of data.
@@ -64,4 +71,510 @@ public interface IDataSource<T> {
      */
     @Nullable
     IDataSourceLocation getLocation();
+
+
+    /* ********************** */
+    /*      Load methods      */
+    /* ********************** */
+
+    /**
+     * Load a file into the {@link IDataSource}.
+     *
+     * @param filePath Path of the file.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull String filePath);
+
+    /**
+     * Load a file into the {@link IDataSource}.
+     *
+     * @param filePath Path of the file.
+     * @param delete   True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull String filePath, boolean delete);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param filePath  Path of the file.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull String filePath, @NotNull String dataSetId);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param filePath  Path of the file.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull String filePath, @NotNull String dataSetId, boolean delete);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param filePath  Path of the file.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @param encoding  Encoding of the loaded file.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull String filePath, @NotNull String dataSetId, @Nullable String encoding, boolean delete);
+
+    /**
+     * Load a file into the {@link IDataSource}.
+     *
+     * @param url {@link URL} of the file.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull URL url);
+
+    /**
+     * Load a file into the {@link IDataSource}.
+     *
+     * @param url    {@link URL} of the file.
+     * @param delete True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull URL url, boolean delete);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param url       {@link URL} of the file.
+     * @param dataSetId Name of the table.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull URL url, @NotNull String dataSetId);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param url       {@link URL} of the file.
+     * @param dataSetId Name of the table.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull URL url, @NotNull String dataSetId, boolean delete);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param url       {@link URL} of the file.
+     * @param dataSetId Name of the table
+     * @param encoding  Encoding of the loaded file.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull URL url, @NotNull String dataSetId, @Nullable String encoding, boolean delete);
+
+    /**
+     * Load a file into the {@link IDataSource}.
+     *
+     * @param uri {@link URI} of the file.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull URI uri);
+
+    /**
+     * Load a file into the {@link IDataSource}.
+     *
+     * @param uri    {@link URI} of the file.
+     * @param delete True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull URI uri, boolean delete);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param uri       {@link URI} of the file.
+     * @param dataSetId Name of the table.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull URI uri, @NotNull String dataSetId);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param uri       {@link URI} of the file.
+     * @param dataSetId Name of the table.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull URI uri, @NotNull String dataSetId, boolean delete);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param uri       {@link URI} of the file.
+     * @param dataSetId Name of the table
+     * @param encoding  Encoding of the loaded file.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull URI uri, @NotNull String dataSetId, @Nullable String encoding, boolean delete);
+
+    /**
+     * Load a file into the {@link IDataSource}.
+     *
+     * @param file {@link File}.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull File file);
+
+    /**
+     * Load a file into the {@link IDataSource}.
+     *
+     * @param file   {@link File}.
+     * @param delete True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull File file, boolean delete);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param file      {@link File}.
+     * @param dataSetId Name of the table.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull File file, @NotNull String dataSetId);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param file      {@link File}.
+     * @param dataSetId Name of the table.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull File file, @NotNull String dataSetId, boolean delete);
+
+    /**
+     * Load a file to the {@link IDataSource}.
+     *
+     * @param file      {@link File}.
+     * @param dataSetId Name of the table
+     * @param encoding  Encoding of the loaded file.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull File file, @NotNull String dataSetId, @Nullable String encoding, boolean delete);
+
+    /**
+     * Load a table from another {@link IDataSource}.
+     *
+     * @param properties     Properties used to connect to the database.
+     * @param inputdataSetId Name of the table to import.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull Map<String, String> properties, @NotNull String inputdataSetId);
+
+
+    /**
+     * Load a table from another {@link IDataSource}.
+     *
+     * @param properties      Properties used to connect to the database.
+     * @param inputdataSetId  Name of the table to import.
+     * @param outputdataSetId Name of the imported table in the database.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull Map<String, String> properties, @NotNull String inputdataSetId,
+                    @NotNull String outputdataSetId);
+
+    /**
+     * Load a table from another {@link IDataSource}.
+     *
+     * @param properties     Properties used to connect to the database.
+     * @param inputdataSetId Name of the table to import.
+     * @param delete         True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull Map<String, String> properties, @NotNull String inputdataSetId, boolean delete);
+
+    /**
+     * Load a table from another {@link IDataSource}.
+     *
+     * @param properties      Properties used to connect to the database.
+     * @param inputdataSetId  Name of the table to import.
+     * @param outputdataSetId Name of the imported table in the database.
+     * @param delete          True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return The {@link IDataSet} containing the loaded data.
+     */
+    @Nullable
+    IDataSet<?> load(@NotNull Map<String, String> properties, @NotNull String inputdataSetId,
+                    @NotNull String outputdataSetId, boolean delete);
+
+
+    /* ********************** */
+    /*      Save methods      */
+    /* ********************** */
+
+    /**
+     * Save a table into a file.
+     *
+     * @param dataSetId Name of the table to save.
+     * @param filePath  Path of the file where the table will be saved.
+     * @return True if the file has been successfully saved, false otherwise.
+     */
+    boolean save(@NotNull String dataSetId, @NotNull String filePath);
+
+    /**
+     * Save a table into a file.
+     *
+     * @param dataSetId Name of the table to save.
+     * @param filePath  Path of the file where the table will be saved.
+     * @param encoding  Encoding of the file.
+     * @return True if the file has been successfully saved, false otherwise.
+     */
+    boolean save(@NotNull String dataSetId, @NotNull String filePath, @Nullable String encoding);
+
+    /**
+     * Save a table into a file.
+     *
+     * @param dataSetId Name of the table to save.
+     * @param uri       {@link URI} of the file where the table will be saved.
+     * @return True if the file has been successfully saved, false otherwise.
+     */
+    boolean save(@NotNull String dataSetId, @NotNull URI uri);
+
+    /**
+     * Save a table into a file.
+     *
+     * @param dataSetId Name of the table to save.
+     * @param uri       {@link URI} of the file where the table will be saved.
+     * @param encoding  Encoding of the file.
+     * @return True if the file has been successfully saved, false otherwise.
+     */
+    boolean save(@NotNull String dataSetId, @NotNull URI uri, @Nullable String encoding);
+
+    /**
+     * Save a table into a file.
+     *
+     * @param dataSetId Name of the table to save.
+     * @param url       {@link URL} of the file where the table will be saved.
+     * @return True if the file has been successfully saved, false otherwise.
+     */
+    boolean save(@NotNull String dataSetId, @NotNull URL url);
+
+    /**
+     * Save a table into a file.
+     *
+     * @param dataSetId Name of the table to save.
+     * @param url       {@link URL} of the file where the table will be saved.
+     * @param encoding  Encoding of the file.
+     * @return True if the file has been successfully saved, false otherwise.
+     */
+    boolean save(@NotNull String dataSetId, @NotNull URL url, @Nullable String encoding);
+
+    /**
+     * Save a table into a file.
+     *
+     * @param dataSetId Name of the table to save.
+     * @param file      {@link File} of the file where the table will be saved.
+     * @return True if the file has been successfully saved, false otherwise.
+     */
+    boolean save(@NotNull String dataSetId, @NotNull File file);
+
+    /**
+     * Save a table into a file.
+     *
+     * @param dataSetId Name of the table to save.
+     * @param file      {@link File} of the file where the table will be saved.
+     * @param encoding  Encoding of the file.
+     * @return True if the file has been successfully saved, false otherwise.
+     */
+    boolean save(@NotNull String dataSetId, @NotNull File file, @Nullable String encoding);
+
+
+    /* ********************** */
+    /*      Link methods      */
+    /* ********************** */
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param filePath  Path of the file.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull String filePath, @NotNull String dataSetId, boolean delete);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param filePath  Path of the file.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull String filePath, @NotNull String dataSetId);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param filePath Path of the file.
+     * @param delete   True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull String filePath, boolean delete);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param filePath Path of the file to link.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull String filePath);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param uri       {@link URI} of the file.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull URI uri, @Nullable String dataSetId, boolean delete);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param uri       {@link URI} of the file.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull URI uri, @Nullable String dataSetId);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param uri    {@link URI} of the file.
+     * @param delete True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull URI uri, boolean delete);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param uri {@link URI} of the file.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull URI uri);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param url       {@link URL} of the file.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull URL url, @Nullable String dataSetId, boolean delete);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param url       {@link URI} of the file.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull URL url, @Nullable String dataSetId);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param url    {@link URI} of the file.
+     * @param delete True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull URL url, boolean delete);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param url {@link URI} of the file.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull URL url);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param file      {@link File}.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @param delete    True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull File file, @NotNull String dataSetId, boolean delete);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param file      {@link File}.
+     * @param dataSetId Identifier of the {@link IDataSet}.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull File file, @NotNull String dataSetId);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param file   {@link File}.
+     * @param delete True to delete the {@link IDataSet} if exists, false otherwise.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull File file, boolean delete);
+
+    /**
+     * Link a file to the {@link IDataSource}.
+     *
+     * @param file {@link File}.
+     * @return A {@link IDataSet} representing the linked file.
+     */
+    @Nullable
+    IDataSet<?> link(@NotNull File file);
 }

--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/datasource/IJdbcDataSource.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/datasource/IJdbcDataSource.java
@@ -114,6 +114,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param filePath Path of the file.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull String filePath);
 
@@ -124,6 +125,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete   True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull String filePath, boolean delete);
 
@@ -134,6 +136,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param tableName Name of the table.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull String filePath, @NotNull String tableName);
 
@@ -145,6 +148,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull String filePath, @NotNull String tableName, boolean delete);
 
@@ -157,6 +161,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull String filePath, @NotNull String tableName, @Nullable String encoding, boolean delete);
 
@@ -166,6 +171,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param url {@link URL} of the file.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull URL url);
 
@@ -176,6 +182,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull URL url, boolean delete);
 
@@ -186,6 +193,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param tableName Name of the table.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull URL url, @NotNull String tableName);
 
@@ -197,6 +205,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull URL url, @NotNull String tableName, boolean delete);
 
@@ -209,6 +218,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull URL url, @NotNull String tableName, @Nullable String encoding, boolean delete);
 
@@ -218,6 +228,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param uri {@link URI} of the file.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull URI uri);
 
@@ -228,6 +239,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull URI uri, boolean delete);
 
@@ -238,6 +250,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param tableName Name of the table.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull URI uri, @NotNull String tableName);
 
@@ -249,6 +262,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull URI uri, @NotNull String tableName, boolean delete);
 
@@ -261,6 +275,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull URI uri, @NotNull String tableName, @Nullable String encoding, boolean delete);
 
@@ -270,6 +285,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param file {@link File}.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull File file);
 
@@ -280,6 +296,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull File file, boolean delete);
 
@@ -290,6 +307,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param tableName Name of the table.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull File file, @NotNull String tableName);
 
@@ -301,6 +319,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull File file, @NotNull String tableName, boolean delete);
 
@@ -313,6 +332,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull File file, @NotNull String tableName, @Nullable String encoding, boolean delete);
 
@@ -323,9 +343,9 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param inputTableName Name of the table to import.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull Map<String, String> properties, @NotNull String inputTableName);
-
 
     /**
      * Load a table from another database.
@@ -335,6 +355,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param outputTableName Name of the imported table in the database.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull Map<String, String> properties, @NotNull String inputTableName,
                     @NotNull String outputTableName);
@@ -347,6 +368,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete         True to delete the outputTableName if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull Map<String, String> properties, @NotNull String inputTableName, boolean delete);
 
@@ -359,6 +381,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete          True to delete the outputTableName if exists, false otherwise.
      * @return The {@link IJdbcTable} containing the loaded data.
      */
+    @Override
     @Nullable
     IJdbcTable load(@NotNull Map<String, String> properties, @NotNull String inputTableName,
                     @NotNull String outputTableName, boolean delete);
@@ -375,6 +398,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param filePath  Path of the file where the table will be saved.
      * @return True if the file has been successfully saved, false otherwise.
      */
+    @Override
     boolean save(@NotNull String tableName, @NotNull String filePath);
 
     /**
@@ -385,6 +409,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param encoding  Encoding of the file.
      * @return True if the file has been successfully saved, false otherwise.
      */
+    @Override
     boolean save(@NotNull String tableName, @NotNull String filePath, @Nullable String encoding);
 
     /**
@@ -394,6 +419,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param uri       {@link URI} of the file where the table will be saved.
      * @return True if the file has been successfully saved, false otherwise.
      */
+    @Override
     boolean save(@NotNull String tableName, @NotNull URI uri);
 
     /**
@@ -404,6 +430,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param encoding  Encoding of the file.
      * @return True if the file has been successfully saved, false otherwise.
      */
+    @Override
     boolean save(@NotNull String tableName, @NotNull URI uri, @Nullable String encoding);
 
     /**
@@ -413,6 +440,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param url       {@link URL} of the file where the table will be saved.
      * @return True if the file has been successfully saved, false otherwise.
      */
+    @Override
     boolean save(@NotNull String tableName, @NotNull URL url);
 
     /**
@@ -423,6 +451,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param encoding  Encoding of the file.
      * @return True if the file has been successfully saved, false otherwise.
      */
+    @Override
     boolean save(@NotNull String tableName, @NotNull URL url, @Nullable String encoding);
 
     /**
@@ -432,6 +461,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param file      {@link File} of the file where the table will be saved.
      * @return True if the file has been successfully saved, false otherwise.
      */
+    @Override
     boolean save(@NotNull String tableName, @NotNull File file);
 
     /**
@@ -442,6 +472,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param encoding  Encoding of the file.
      * @return True if the file has been successfully saved, false otherwise.
      */
+    @Override
     boolean save(@NotNull String tableName, @NotNull File file, @Nullable String encoding);
 
 
@@ -457,6 +488,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull String filePath, @NotNull String tableName, boolean delete);
 
@@ -467,6 +499,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param tableName Name of the database table.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull String filePath, @NotNull String tableName);
 
@@ -477,6 +510,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete   True to delete the table if exists, false otherwise.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull String filePath, boolean delete);
 
@@ -486,6 +520,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param filePath Path of the file to link.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull String filePath);
 
@@ -497,6 +532,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull URI uri, @Nullable String tableName, boolean delete);
 
@@ -507,6 +543,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param tableName Name of the database table.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull URI uri, @Nullable String tableName);
 
@@ -526,6 +563,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param uri {@link URI} of the file.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull URI uri);
 
@@ -537,6 +575,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull URL url, @Nullable String tableName, boolean delete);
 
@@ -547,6 +586,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param tableName Name of the database table.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull URL url, @Nullable String tableName);
 
@@ -557,6 +597,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete True to delete the table if exists, false otherwise.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull URL url, boolean delete);
 
@@ -566,6 +607,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param url {@link URI} of the file.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull URL url);
 
@@ -577,6 +619,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete    True to delete the table if exists, false otherwise.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull File file, @NotNull String tableName, boolean delete);
 
@@ -587,6 +630,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param tableName Name of the database table.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull File file, @NotNull String tableName);
 
@@ -597,6 +641,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param delete True to delete the table if exists, false otherwise.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull File file, boolean delete);
 
@@ -606,6 +651,7 @@ public interface IJdbcDataSource extends IDataSource<Object>, GroovyObject, Data
      * @param file {@link File}.
      * @return A {@link IJdbcTable} representing the linked file.
      */
+    @Override
     @Nullable
     IJdbcTable link(@NotNull File file);
 

--- a/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/IJdbcTableTest.java
+++ b/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/IJdbcTableTest.java
@@ -304,6 +304,11 @@ public class IJdbcTableTest {
         }
 
         @Override
+        public IDataSet<?> filter(String filter) {
+            return null;
+        }
+
+        @Override
         public boolean next() throws SQLException {
             if (!sqlException) {
                 return rowIndex++ < data.length;

--- a/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/ITableTest.java
+++ b/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/ITableTest.java
@@ -345,6 +345,31 @@ public class ITableTest {
         }
 
         @Override
+        public boolean previous() throws Exception {
+            return false;
+        }
+
+        @Override
+        public boolean first() throws Exception {
+            return false;
+        }
+
+        @Override
+        public boolean last() throws Exception {
+            return false;
+        }
+
+        @Override
+        public boolean isFirst() throws Exception {
+            return false;
+        }
+
+        @Override
+        public boolean isLast() throws Exception {
+            return false;
+        }
+
+        @Override
         public Collection<String> getUniqueValues(@NotNull String column) {
             return null;
         }
@@ -558,6 +583,11 @@ public class ITableTest {
         @Override
         public boolean reload() {
             return false;
+        }
+
+        @Override
+        public IDataSet<?> filter(String filter) {
+            return null;
         }
 
         @Override

--- a/data-manager/dataframe/src/main/java/org/orbisgis/orbisdata/datamanager/dataframe/DataFrame.java
+++ b/data-manager/dataframe/src/main/java/org/orbisgis/orbisdata/datamanager/dataframe/DataFrame.java
@@ -572,6 +572,37 @@ public class DataFrame implements smile.data.DataFrame, ITable<BaseVector> {
     }
 
     @Override
+    public boolean previous() {
+        if(row > 0){
+            row--;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean first() {
+        row = 0;
+        return true;
+    }
+
+    @Override
+    public boolean last() {
+        row = getRowCount()-1;
+        return true;
+    }
+
+    @Override
+    public boolean isFirst() {
+        return row == 0;
+    }
+
+    @Override
+    public boolean isLast() {
+        return row == getRowCount()-1;
+    }
+
+    @Override
     public Collection<String> getUniqueValues(@NotNull String column) {
         int colIndex = columnIndex(column);
         List<String> values = new ArrayList<>();
@@ -650,6 +681,12 @@ public class DataFrame implements smile.data.DataFrame, ITable<BaseVector> {
         List<String> col = new ArrayList<>(getColumns());
         col.removeAll(columns);
         return of(drop(col.toArray(new String[0])));
+    }
+
+    @Override
+    @Nullable
+    public ITable<?> filter(String filter) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcSpatialTable.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcSpatialTable.java
@@ -43,9 +43,7 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.orbisgis.commons.annotations.NotNull;
 import org.orbisgis.commons.annotations.Nullable;
-import org.orbisgis.orbisdata.datamanager.api.dataset.DataBaseType;
-import org.orbisgis.orbisdata.datamanager.api.dataset.IJdbcSpatialTable;
-import org.orbisgis.orbisdata.datamanager.api.dataset.IRaster;
+import org.orbisgis.orbisdata.datamanager.api.dataset.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -339,5 +337,11 @@ public abstract class JdbcSpatialTable extends JdbcTable implements IJdbcSpatial
             LOGGER.error("Unable to get the metadata.", e);
             return null;
         }
+    }
+
+    @Override
+    @Nullable
+    public ISpatialTable<?> filter(String filter) {
+        return where(filter).getSpatialTable();
     }
 }

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTable.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTable.java
@@ -49,10 +49,7 @@ import org.orbisgis.commons.annotations.Nullable;
 import org.orbisgis.commons.printer.Ascii;
 import org.orbisgis.commons.printer.Html;
 import org.orbisgis.commons.printer.ICustomPrinter;
-import org.orbisgis.orbisdata.datamanager.api.dataset.DataBaseType;
-import org.orbisgis.orbisdata.datamanager.api.dataset.IJdbcSpatialTable;
-import org.orbisgis.orbisdata.datamanager.api.dataset.IJdbcTable;
-import org.orbisgis.orbisdata.datamanager.api.dataset.ITable;
+import org.orbisgis.orbisdata.datamanager.api.dataset.*;
 import org.orbisgis.orbisdata.datamanager.api.dsl.IConditionOrOptionBuilder;
 import org.orbisgis.orbisdata.datamanager.api.dsl.IOptionBuilder;
 import org.orbisgis.orbisdata.datamanager.jdbc.dsl.OptionBuilder;
@@ -605,6 +602,12 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
     @Override
     public IOptionBuilder limit(int limitCount) {
         return new OptionBuilder(getQuery(), getJdbcDataSource()).limit(limitCount);
+    }
+
+    @Override
+    @Nullable
+    public ITable<?> filter(String filter) {
+        return where(filter).getTable();
     }
 
     @Override

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,10 @@ make it compatible with `smile` API)
 + Fix bug on DSL built tables.
 + Add a method `getSummary()` on the `IDataSet` interface.
 + Add the `ProgressMonitor` mechanism.
-+ Add get*Type*() methods on `ITable` interface
-+ Merge `createSpatialIndex` in `createIndex()`
-+ Rename `getShape()` into `getSize()`
-+ Add `next()` methods on `ITable` interface
++ Add get*Type*() methods on `ITable` interface.
++ Merge `createSpatialIndex` in `createIndex()`.
++ Rename `getShape()` into `getSize()`.
++ Add `next()` methods on `ITable` interface.
++ Move  `link`, `load`, `save` methods from `IJdbcDataSource` to `IDataSource`.
++ Add `previous()`, `first()`, `last()`, `isFirst()`, `isLast()` methods to `ITable`.
++ Add `IDataSet<?> filter(String filter)` method to IDataSet.


### PR DESCRIPTION
Move  `link`, `load`, `save` methods from `IJdbcDataSource` to `IDataSource`.
Add `previous()`, `first()`, `last()`, `isFirst()`, `isLast()` methods to `ITable`.
Add `IDataSet<?> filter(String filter)` method to `IDataSet`.

Link to #217.