### PR TITLE
firstRow, getColumnNames and ResultSet type.

### DIFF
--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dataset/ITable.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dataset/ITable.java
@@ -541,8 +541,12 @@ public interface ITable<T, U> extends IMatrix<T, U> {
      *
      * @return A {@link Stream} of {@link T} objects.
      */
+    @Nullable
     Stream<U> stream();
 
     @Override
     ITable<T, U> filter(String filter);
+
+    @NotNull
+    Map<String, Object> firstRow();
 }

--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/datasource/IJdbcDataSource.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/datasource/IJdbcDataSource.java
@@ -104,6 +104,15 @@ public interface IJdbcDataSource extends IDataSource<ResultSet>, GroovyObject, D
      */
     boolean hasTable(@NotNull String tableName);
 
+    /**
+     * Returns the names of the column of the given table.
+     *
+     * @param location Location of the table with the pattern : [[catalog.]schema.]table
+     * @return The names of the column of the given table.
+     */
+    @Nullable
+    Collection<String> getColumnNames(String location);
+
 
     /* ********************** */
     /*      Load methods      */

--- a/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/IJdbcTableTest.java
+++ b/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/IJdbcTableTest.java
@@ -314,6 +314,12 @@ public class IJdbcTableTest {
             return null;
         }
 
+        @NotNull
+        @Override
+        public Map<String, Object> firstRow() {
+            return null;
+        }
+
         @Override
         public boolean next() throws SQLException {
             if (!sqlException) {

--- a/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/ITableTest.java
+++ b/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/ITableTest.java
@@ -564,6 +564,12 @@ public class ITableTest {
             return null;
         }
 
+        @NotNull
+        @Override
+        public Map<String, Object> firstRow() {
+            return null;
+        }
+
         @Override
         public String getLocation() {
             return null;

--- a/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/datasource/IJdbcDataSourceTest.java
+++ b/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/datasource/IJdbcDataSourceTest.java
@@ -499,6 +499,12 @@ public class IJdbcDataSourceTest {
             return false;
         }
 
+        @Nullable
+        @Override
+        public Collection<String> getColumnNames(String location) {
+            return null;
+        }
+
         @Override
         public Connection getConnection() throws SQLException {
             return null;

--- a/data-manager/dataframe/src/main/java/org/orbisgis/orbisdata/datamanager/dataframe/DataFrame.java
+++ b/data-manager/dataframe/src/main/java/org/orbisgis/orbisdata/datamanager/dataframe/DataFrame.java
@@ -709,6 +709,21 @@ public class DataFrame implements smile.data.DataFrame, ITable<BaseVector, Tuple
     }
 
     @Override
+    @NotNull
+    public Map<String, Object> firstRow() {
+        Map<String, Object> map = new HashMap<>();
+        if(first()){
+            for(String column : getColumns()){
+                map.put(column, getObject(column));
+            }
+        }
+        else{
+            LOGGER.error("Unable to go to the first row.");
+        }
+        return map;
+    }
+
+    @Override
     public boolean isSpatial() {
         return false;
     }

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSource.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSource.java
@@ -708,6 +708,17 @@ public abstract class JdbcDataSource extends Sql implements IJdbcDataSource, ISe
     }
 
     @Override
+    @Nullable
+    public Collection<String> getColumnNames(String location){
+        try {
+            return JDBCUtilities.getFieldNames(getConnection().getMetaData(), location);
+        } catch (SQLException e) {
+            LOGGER.error("Unable to get the column names of the table " + location + ".", e);
+            return null;
+        }
+    }
+
+    @Override
     public IJdbcTable getDataSet(@NotNull String dataSetName) {
         List<String> geomFields;
         try {

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTable.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTable.java
@@ -552,6 +552,29 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable, 
     }
 
     @Override
+    @NotNull
+    public Map<String, Object> firstRow() {
+        Map<String, Object> map = new HashMap<>();
+        if(isEmpty()){
+            return map;
+        }
+        ResultSet rs = getResultSetLimit(1);
+        try {
+            rs.next();
+        } catch (SQLException e) {
+            LOGGER.error("Unable to get first row.", e);
+        }
+        for(String column : getColumns()){
+            try {
+                map.put(column, rs.getObject(column));
+            } catch (SQLException e) {
+                LOGGER.error("Unable to get data from first row.", e);
+            }
+        }
+        return map;
+    }
+
+    @Override
     public boolean save(@NotNull String filePath, String encoding) {
         try {
             String toSave = getTableLocation() == null ? "(" + getBaseQuery() + ")" : getTableLocation().toString(getDbType());

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/ResultSetSpliterator.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/ResultSetSpliterator.java
@@ -69,6 +69,9 @@ public class ResultSetSpliterator implements Spliterator<ResultSet> {
 
     @Override
     public boolean tryAdvance(Consumer<? super ResultSet> consumer) {
+        if(size == 0){
+            return false;
+        }
         consumer.accept(rs);
         try {
             return rs.next();

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/postgis/POSTGIS.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/postgis/POSTGIS.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -150,7 +151,15 @@ public class POSTGIS extends JdbcDataSource {
         }
         StatementWrapper statement;
         try {
-            statement = (StatementWrapper) connectionWrapper.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
+            DatabaseMetaData dbdm = connectionWrapper.getMetaData();
+            int type = ResultSet.TYPE_FORWARD_ONLY;
+            if(dbdm.supportsResultSetType(ResultSet.TYPE_SCROLL_SENSITIVE)){
+                type = ResultSet.TYPE_SCROLL_SENSITIVE;
+            }
+            else if(dbdm.supportsResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)){
+                type = ResultSet.TYPE_SCROLL_INSENSITIVE;
+            }
+            statement = (StatementWrapper) connectionWrapper.createStatement(type, ResultSet.CONCUR_UPDATABLE);
         } catch (SQLException e) {
             LOGGER.error("Unable to create Statement.\n" + e.getLocalizedMessage());
             return null;
@@ -182,7 +191,15 @@ public class POSTGIS extends JdbcDataSource {
         }
         StatementWrapper statement;
         try {
-            statement = (StatementWrapper) connectionWrapper.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
+            DatabaseMetaData dbdm = connectionWrapper.getMetaData();
+            int type = ResultSet.TYPE_FORWARD_ONLY;
+            if(dbdm.supportsResultSetType(ResultSet.TYPE_SCROLL_SENSITIVE)){
+                type = ResultSet.TYPE_SCROLL_SENSITIVE;
+            }
+            else if(dbdm.supportsResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)){
+                type = ResultSet.TYPE_SCROLL_INSENSITIVE;
+            }
+            statement = (StatementWrapper) connectionWrapper.createStatement(type, ResultSet.CONCUR_UPDATABLE);
         } catch (SQLException e) {
             LOGGER.error("Unable to create Statement.\n" + e.getLocalizedMessage());
             return null;

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSourceTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSourceTest.java
@@ -778,6 +778,50 @@ class JdbcDataSourceTest {
     }
 
     /**
+     * Test the {@link JdbcDataSource#getColumnNames(String)} method.
+     */
+    @Test
+    void testGetColumnNames() {
+        Collection<String> names = ds1.getColumnNames("JDBCDATASOURCETEST.PUBLIC.TEST");
+        assertNotNull(names);
+        assertEquals(3, names.size());
+        assertTrue(names.contains("ID"));
+        assertTrue(names.contains("THE_GEOM"));
+        assertTrue(names.contains("TEXT"));
+        names = ds1.getColumnNames("PUBLIC.TEST");
+        assertNotNull(names);
+        assertEquals(3, names.size());
+        assertTrue(names.contains("ID"));
+        assertTrue(names.contains("THE_GEOM"));
+        assertTrue(names.contains("TEXT"));
+        names = ds1.getColumnNames("TEST");
+        assertNotNull(names);
+        assertEquals(3, names.size());
+        assertTrue(names.contains("ID"));
+        assertTrue(names.contains("THE_GEOM"));
+        assertTrue(names.contains("TEXT"));
+
+        names = ds2.getColumnNames("JDBCDATASOURCETEST.PUBLIC.TEST");
+        assertNotNull(names);
+        assertEquals(3, names.size());
+        assertTrue(names.contains("ID"));
+        assertTrue(names.contains("THE_GEOM"));
+        assertTrue(names.contains("TEXT"));
+        names = ds2.getColumnNames("PUBLIC.TEST");
+        assertNotNull(names);
+        assertEquals(3, names.size());
+        assertTrue(names.contains("ID"));
+        assertTrue(names.contains("THE_GEOM"));
+        assertTrue(names.contains("TEXT"));
+        names = ds2.getColumnNames("TEST");
+        assertNotNull(names);
+        assertEquals(3, names.size());
+        assertTrue(names.contains("ID"));
+        assertTrue(names.contains("THE_GEOM"));
+        assertTrue(names.contains("TEXT"));
+    }
+
+    /**
      * Test the {@link JdbcDataSource#hasTable(String)} method.
      */
     @Test

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
@@ -252,6 +252,94 @@ class JdbcTableTest {
             }
         }).collect(Collectors.joining(" ; "));
         assertEquals("POINT (0 0) ; POINT (0 1)", str);
+
+        str = getTempTable().stream().map(resultSet -> {
+            try {
+                return resultSet.getObject(COL_THE_GEOM).toString();
+            } catch (SQLException throwables) {
+                throwables.printStackTrace();
+                return "";
+            }
+        }).collect(Collectors.joining(" ; "));
+        assertEquals("", str);
+
+        str = getBuiltTable().stream().map(resultSet -> {
+            try {
+                return resultSet.getObject(COL_THE_GEOM).toString();
+            } catch (SQLException throwables) {
+                throwables.printStackTrace();
+                return "";
+            }
+        }).collect(Collectors.joining(" ; "));
+        assertEquals("POINT (0 0) ; POINT (0 1)", str);
+
+        str = getEmptyTable().stream().map(resultSet -> {
+            try {
+                return resultSet.getObject(COL_THE_GEOM).toString();
+            } catch (SQLException throwables) {
+                throwables.printStackTrace();
+                return "";
+            }
+        }).collect(Collectors.joining(" ; "));
+        assertEquals("", str);
+
+        str = getLinkedTable().stream().map(resultSet -> {
+            try {
+                return resultSet.getObject(COL_THE_GEOM).toString();
+            } catch (SQLException throwables) {
+                throwables.printStackTrace();
+                return "";
+            }
+        }).collect(Collectors.joining(" ; "));
+        assertEquals("POINT (0 0) ; POINT (0 1)", str);
+    }
+
+    @Test
+    void firstRowTest(){
+        Map<String, Object> map = getTable().firstRow();
+        assertEquals(5, map.size());
+        assertTrue(map.containsKey(COL_ID));
+        assertEquals(1, map.get(COL_ID));
+        assertTrue(map.containsKey(COL_THE_GEOM));
+        assertEquals("POINT (0 0)", map.get(COL_THE_GEOM).toString());
+        assertTrue(map.containsKey(COL_THE_GEOM2.toUpperCase()));
+        assertEquals("POINT (1 1)", map.get(COL_THE_GEOM2.toUpperCase()).toString());
+        assertTrue(map.containsKey(COL_VALUE));
+        assertEquals("2.3", map.get(COL_VALUE).toString());
+        assertTrue(map.containsKey(COL_MEANING));
+        assertEquals("Simple points", map.get(COL_MEANING));
+
+        map = getLinkedTable().firstRow();
+        assertEquals(5, map.size());
+        assertTrue(map.containsKey(COL_ID));
+        assertEquals(1, map.get(COL_ID));
+        assertTrue(map.containsKey(COL_THE_GEOM));
+        assertEquals("POINT (0 0)", map.get(COL_THE_GEOM).toString());
+        assertTrue(map.containsKey(COL_THE_GEOM2.toUpperCase()));
+        assertEquals("POINT (1 1)", map.get(COL_THE_GEOM2.toUpperCase()).toString());
+        assertTrue(map.containsKey(COL_VALUE));
+        assertEquals("2.3", map.get(COL_VALUE).toString());
+        assertTrue(map.containsKey(COL_MEANING));
+        assertEquals("Simple points", map.get(COL_MEANING));
+
+        map = getBuiltTable().firstRow();
+        assertEquals(5, map.size());
+        assertTrue(map.containsKey(COL_ID));
+        assertEquals(1, map.get(COL_ID));
+        assertTrue(map.containsKey(COL_THE_GEOM));
+        assertEquals("POINT (0 0)", map.get(COL_THE_GEOM).toString());
+        assertTrue(map.containsKey(COL_THE_GEOM2.toUpperCase()));
+        assertEquals("POINT (1 1)", map.get(COL_THE_GEOM2.toUpperCase()).toString());
+        assertTrue(map.containsKey(COL_VALUE));
+        assertEquals("2.3", map.get(COL_VALUE).toString());
+        assertTrue(map.containsKey(COL_MEANING));
+        assertEquals("Simple points", map.get(COL_MEANING));
+
+        map = getTempTable().firstRow();
+        assertTrue(map.isEmpty());
+
+        map = getEmptyTable().firstRow();
+        assertTrue(map.isEmpty());
     }
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,3 +26,5 @@ make it compatible with `smile` API)
 + Add `IDataSet<?> filter(String filter)` method to `IDataSet`.
 + Add `stream()` method to `IDataSet`.
 + Make `IDataSet` have two value parameter : one for the iterator, a second for the stream.
++ Improve `ResultSet` type detection.
++ Add `getColumnNames(String)` metods to `IJdbcDataSource`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,4 +27,5 @@ make it compatible with `smile` API)
 + Add `stream()` method to `IDataSet`.
 + Make `IDataSet` have two value parameter : one for the iterator, a second for the stream.
 + Improve `ResultSet` type detection.
-+ Add `getColumnNames(String)` metods to `IJdbcDataSource`.
++ Add `getColumnNames(String)` method to `IJdbcDataSource`.
++ Add `firstRow()` method to `ITable`


### PR DESCRIPTION
Improve `ResultSet` type detection.
Add `getColumnNames(String)` method to `IJdbcDataSource`.
Add `firstRow()` method to `ITable`

Linked to #232, #233, #235