### PR TITLE
Stability, improvement and test of process.check package.

### DIFF
--- a/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/ICheckClosureBuilder.java
+++ b/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/ICheckClosureBuilder.java
@@ -40,12 +40,11 @@ package org.orbisgis.orbisdata.processmanager.api.check;
 import groovy.lang.Closure;
 import org.orbisgis.commons.annotations.NotNull;
 import org.orbisgis.commons.annotations.Nullable;
-import org.orbisgis.orbisdata.processmanager.api.IProcess;
-import org.orbisgis.orbisdata.processmanager.api.IProcessMapper;
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
 
 /**
  * Interface for the definition of which closure is provided for the Process check execution.
- * Instance is get from the {@link ICheckDataBuilder#with(Object...)}.
+ * Instance is get from the {@link ICheckDataBuilder#with(IInOutPut...)}.
  *
  * @author Erwan Bocher (CNRS)
  * @author Sylvain PALOMINOS (UBS Lab-STICC 2019-2020)

--- a/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/ICheckClosureBuilder.java
+++ b/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/ICheckClosureBuilder.java
@@ -39,21 +39,26 @@ package org.orbisgis.orbisdata.processmanager.api.check;
 
 import groovy.lang.Closure;
 import org.orbisgis.commons.annotations.NotNull;
+import org.orbisgis.commons.annotations.Nullable;
+import org.orbisgis.orbisdata.processmanager.api.IProcess;
+import org.orbisgis.orbisdata.processmanager.api.IProcessMapper;
 
 /**
- * Interface for the definition of which closure is provided for the getProcess check execution.
+ * Interface for the definition of which closure is provided for the Process check execution.
+ * Instance is get from the {@link ICheckDataBuilder#with(Object...)}.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2019)
+ * @author Sylvain PALOMINOS (UBS Lab-STICC 2019-2020)
  */
 public interface ICheckClosureBuilder {
 
     /**
      * Sets the {@link Closure} to execute to perform the check.
+     * If the {@link Closure} is null, just check equality of data.
      *
      * @param cl {@link Closure} to execute to perform the check.
      * @return A {@link ICheckClosureBuilder} to continue the check building.
      */
     @NotNull
-    ICheckOptionBuilder check(@NotNull Closure<?> cl);
+    ICheckOptionBuilder check(@Nullable Closure<?> cl);
 }

--- a/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/ICheckDataBuilder.java
+++ b/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/ICheckDataBuilder.java
@@ -37,12 +37,17 @@
 package org.orbisgis.orbisdata.processmanager.api.check;
 
 import org.orbisgis.commons.annotations.NotNull;
+import org.orbisgis.commons.annotations.Nullable;
+import org.orbisgis.orbisdata.processmanager.api.IProcess;
+import org.orbisgis.orbisdata.processmanager.api.IProcessMapper;
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
 
 /**
- * Interface for the definition of which data are provided for the getProcess check execution.
+ * Interface for the definition of which data are provided for the Process check execution.
+ * Instance is get from the {@link IProcessMapper#after(IProcess)} and  {@link IProcessMapper#before(IProcess)}.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2019)
+ * @author Sylvain PALOMINOS (UBS Lab-STICC 2019-2020)
  */
 public interface ICheckDataBuilder {
 
@@ -53,5 +58,5 @@ public interface ICheckDataBuilder {
      * @return A {@link ICheckClosureBuilder} to continue the check building.
      */
     @NotNull
-    ICheckClosureBuilder with(@NotNull Object... data);
+    ICheckClosureBuilder with(@Nullable IInOutPut... data);
 }

--- a/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/ICheckOptionBuilder.java
+++ b/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/ICheckOptionBuilder.java
@@ -36,14 +36,16 @@
  */
 package org.orbisgis.orbisdata.processmanager.api.check;
 
+import groovy.lang.Closure;
 import org.orbisgis.commons.annotations.NotNull;
 import org.orbisgis.commons.annotations.Nullable;
 
 /**
  * Interface for the definition of the getProcess check execution options.
+ * Instance is get from the {@link ICheckClosureBuilder#check(Closure)}.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2019)
+ * @author Sylvain PALOMINOS (UBS Lab-STICC 2019)
  */
 public interface ICheckOptionBuilder {
 
@@ -57,6 +59,14 @@ public interface ICheckOptionBuilder {
     ICheckOptionBuilder stopOnFail(@Nullable String message);
 
     /**
+     * Make the check stop the program on fail .
+     *
+     * @return A {@link ICheckOptionBuilder} to continue the check building.
+     */
+    @NotNull
+    ICheckOptionBuilder stopOnFail();
+
+    /**
      * Make the check log the given message and stop the program on success .
      *
      * @param message Message to log.
@@ -64,6 +74,14 @@ public interface ICheckOptionBuilder {
      */
     @NotNull
     ICheckOptionBuilder stopOnSuccess(@Nullable String message);
+
+    /**
+     * Make the check stop the program on success .
+     *
+     * @return A {@link ICheckOptionBuilder} to continue the check building.
+     */
+    @NotNull
+    ICheckOptionBuilder stopOnSuccess();
 
     /**
      * Make the check log the given message and continue the program on fail .
@@ -75,6 +93,14 @@ public interface ICheckOptionBuilder {
     ICheckOptionBuilder continueOnFail(@Nullable String message);
 
     /**
+     * Make the check continue the program on fail .
+     *
+     * @return A {@link ICheckOptionBuilder} to continue the check building.
+     */
+    @NotNull
+    ICheckOptionBuilder continueOnFail();
+
+    /**
      * Make the check log the given message and continue the program on success .
      *
      * @param message Message to log.
@@ -82,4 +108,12 @@ public interface ICheckOptionBuilder {
      */
     @NotNull
     ICheckOptionBuilder continueOnSuccess(@Nullable String message);
+
+    /**
+     * Make the check continue the program on success .
+     *
+     * @return A {@link ICheckOptionBuilder} to continue the check building.
+     */
+    @NotNull
+    ICheckOptionBuilder continueOnSuccess();
 }

--- a/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/IProcessCheck.java
+++ b/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/IProcessCheck.java
@@ -40,74 +40,121 @@ import groovy.lang.Closure;
 import org.orbisgis.commons.annotations.NotNull;
 import org.orbisgis.commons.annotations.Nullable;
 import org.orbisgis.orbisdata.processmanager.api.IProcess;
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Interface for the definition of getProcess check.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2019)
+ * @author Sylvain PALOMINOS (UBS Lab-STICC 2019)
  */
 public interface IProcessCheck {
 
     /**
-     * Continue action.
+     * Enumeration of the action to do after a process check.
      */
-    String CONTINUE = "CONTINUE";
-    /**
-     * Stop action.
-     */
-    String STOP = "STOP";
+    enum Action{CONTINUE, STOP}
 
     /**
-     * Run the check with output data given with {@link #setInOutputs(Object...)} and the input data from the given
-     * {@link LinkedHashMap}. On fail, exit the programme or apply the action set with {@link #onFail(String, String)}.
-     * On success, continue the programme or apply the action set with {@link #onSuccess(String, String)}.
+     * Run the check with output data given with {@link #setInOutputs(IInOutPut...)} and the input data from the given
+     * {@link LinkedHashMap}. On fail, return false and apply the action set with {@link #onFail(Action, String)}.
+     * On success, return true and apply the action set with {@link #onSuccess(Action, String)}.
+     *
+     * I not process have been provided, the default values of the mapper input are checked. The given map represents
+     * the inputs to check as key and there default value as value.
      *
      * @param processInData {@link LinkedHashMap} containing the input data for the {@link IProcess} execution.
+     * @return True if the process should continue, false otherwise
      */
-    void run(@NotNull LinkedHashMap<String, Object> processInData);
+    boolean run(@Nullable LinkedHashMap<String, Object> processInData);
 
     /**
-     * Set the action to do on check fail.
+     * Set the action to do on check fail. If action is null, use {@link Action#STOP} by default.
      *
      * @param action  Action to do on fail.
      * @param message Message to log.
      */
-    void onFail(@NotNull String action, @Nullable String message);
+    void onFail(@Nullable Action action, @Nullable String message);
 
     /**
-     * Set the action to do on check success.
+     * Set the message on check fail. By default use {@link Action#STOP}.
+     *
+     * @param message Message to log.
+     */
+    void onFail(@Nullable String message);
+
+    /**
+     * Set the action to do on check success. If action is null, use {@link Action#STOP} by default.
      *
      * @param action  Action to do on success.
      * @param message Message to log.
      */
-    void onSuccess(@NotNull String action, @Nullable String message);
+    void onSuccess(@Nullable Action action, @Nullable String message);
+
+    /**
+     * Set the message on check success. By default use {@link Action#CONTINUE}.
+     *
+     * @param message Message to log.
+     */
+    void onSuccess(@Nullable String message);
 
     /**
      * Sets the input and output to use inside the check.
      *
      * @param inputOrOutput Input or output list to use for the check.
      */
-    void setInOutputs(@NotNull Object... inputOrOutput);
+    void setInOutputs(@Nullable IInOutPut... inputOrOutput);
+
+    /**
+     * Sets the input and output to use inside the check.
+     *
+     * @param inputOrOutput Input or output list to use for the check.
+     */
+    void setInOutputs(@Nullable List<IInOutPut> inputOrOutput);
+
+    /**
+     * Returns the input and output to use inside the check.
+     *
+     * @return The input or output list to use for the check.
+     */
+    @NotNull
+    Optional<LinkedList<IInOutPut>> getInOutputs();
 
     /**
      * Set the {@link Closure} to call to execute the check.
      *
      * @param cl {@link Closure} to call to execute the check.
      */
-    void setClosure(@NotNull Closure<?> cl);
+    void setClosure(@Nullable Closure<?> cl);
 
     /**
-     * Method executed on check fail.
+     * Returns the {@link Closure} to call to execute the check.
+     *
+     * @return The {@link Closure} to call to execute the check.
      */
-    void fail();
+    @NotNull
+    Optional<Closure<?>> getClosure();
 
     /**
-     * Method executed on check success.
+     * Method executed on check fail. If process should stop, returns true, false otherwise.
+     *
+     * @return False if the process should stop, true otherwise.
+     * @throws IllegalStateException Exception thrown when check should stop.
      */
-    void success();
+    boolean fail() throws IllegalStateException;
+
+    /**
+     * Method executed on check success. If process should stop, returns true, false otherwise.
+     *
+     * @return False if the process should stop, true otherwise.
+     * @throws IllegalStateException Exception thrown when check should stop.
+     */
+    boolean success() throws IllegalStateException;
 
     /**
      * Return the {@link IProcess} concerned by the check.
@@ -115,5 +162,5 @@ public interface IProcessCheck {
      * @return The {@link IProcess} concerned by the check.
      */
     @NotNull
-    IProcess getProcess();
+    Optional<IProcess> getProcess();
 }

--- a/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/IProcessCheck.java
+++ b/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/IProcessCheck.java
@@ -111,19 +111,12 @@ public interface IProcessCheck {
     void setInOutPuts(@Nullable IInOutPut... inputOrOutput);
 
     /**
-     * Sets the input and output to use inside the check.
-     *
-     * @param inputOrOutput Input or output list to use for the check.
-     */
-    void setInOutPuts(@Nullable List<IInOutPut> inputOrOutput);
-
-    /**
      * Returns the input and output to use inside the check.
      *
      * @return The input or output list to use for the check.
      */
     @NotNull
-    Optional<LinkedList<IInOutPut>> getInOutPuts();
+    LinkedList<IInOutPut> getInOutPuts();
 
     /**
      * Set the {@link Closure} to call to execute the check.

--- a/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/IProcessCheck.java
+++ b/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/IProcessCheck.java
@@ -44,7 +44,6 @@ import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -61,7 +60,7 @@ public interface IProcessCheck {
     enum Action{CONTINUE, STOP}
 
     /**
-     * Run the check with output data given with {@link #setInOutputs(IInOutPut...)} and the input data from the given
+     * Run the check with output data given with {@link #setInOutPuts(IInOutPut...)} and the input data from the given
      * {@link LinkedHashMap}. On fail, return false and apply the action set with {@link #onFail(Action, String)}.
      * On success, return true and apply the action set with {@link #onSuccess(Action, String)}.
      *

--- a/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/IProcessCheck.java
+++ b/process-manager/api/src/main/java/org/orbisgis/orbisdata/processmanager/api/check/IProcessCheck.java
@@ -108,14 +108,14 @@ public interface IProcessCheck {
      *
      * @param inputOrOutput Input or output list to use for the check.
      */
-    void setInOutputs(@Nullable IInOutPut... inputOrOutput);
+    void setInOutPuts(@Nullable IInOutPut... inputOrOutput);
 
     /**
      * Sets the input and output to use inside the check.
      *
      * @param inputOrOutput Input or output list to use for the check.
      */
-    void setInOutputs(@Nullable List<IInOutPut> inputOrOutput);
+    void setInOutPuts(@Nullable List<IInOutPut> inputOrOutput);
 
     /**
      * Returns the input and output to use inside the check.
@@ -123,7 +123,7 @@ public interface IProcessCheck {
      * @return The input or output list to use for the check.
      */
     @NotNull
-    Optional<LinkedList<IInOutPut>> getInOutputs();
+    Optional<LinkedList<IInOutPut>> getInOutPuts();
 
     /**
      * Set the {@link Closure} to call to execute the check.

--- a/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/ProcessMapper.java
+++ b/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/ProcessMapper.java
@@ -355,20 +355,18 @@ public class ProcessMapper implements IProcessMapper {
             for (IProcess process : processes) {
                 LinkedHashMap<String, Object> processInData = getInputDataMap(process, dataMap);
                 //Do the before check
-                for (IProcessCheck check : beforeList) {
-                    if (check.getProcess().getIdentifier().equals(process.getIdentifier())) {
-                        check.run(processInData);
-                    }
-                }
+                beforeList.stream()
+                        .filter(check -> check.getProcess().isPresent())
+                        .filter(check -> check.getProcess().get().getIdentifier().equals(process.getIdentifier()))
+                        .forEach(check -> check.run(processInData));
                 //Execute the process
                 process.execute(processInData);
                 storeResults(process);
                 //Do the after check
-                for (IProcessCheck check : afterList) {
-                    if (check.getProcess().getIdentifier().equals(process.getIdentifier())) {
-                        check.run(processInData);
-                    }
-                }
+                afterList.stream()
+                        .filter(check -> check.getProcess().isPresent())
+                        .filter(check -> check.getProcess().get().getIdentifier().equals(process.getIdentifier()))
+                        .forEach(check -> check.run(processInData));
             }
         }
         return true;

--- a/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/check/CheckDataBuilder.java
+++ b/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/check/CheckDataBuilder.java
@@ -37,9 +37,14 @@
 package org.orbisgis.orbisdata.processmanager.process.check;
 
 import org.orbisgis.commons.annotations.NotNull;
+import org.orbisgis.commons.annotations.Nullable;
 import org.orbisgis.orbisdata.processmanager.api.check.ICheckClosureBuilder;
 import org.orbisgis.orbisdata.processmanager.api.check.ICheckDataBuilder;
 import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck;
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
+
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Implementation of the {@link ICheckDataBuilder} interface.
@@ -65,8 +70,13 @@ public class CheckDataBuilder implements ICheckDataBuilder {
 
     @Override
     @NotNull
-    public ICheckClosureBuilder with(@NotNull Object... data) {
-        processCheck.setInOutputs(data);
+    public ICheckClosureBuilder with(@Nullable IInOutPut... data) {
+        if(data != null && (data.length == 0 || Arrays.stream(data).allMatch(Objects::isNull))) {
+            processCheck.setInOutPuts((IInOutPut[]) null);
+        }
+        else {
+            processCheck.setInOutPuts(data);
+        }
         return new CheckClosureBuilder(processCheck);
     }
 }

--- a/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/check/CheckOptionBuilder.java
+++ b/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/check/CheckOptionBuilder.java
@@ -40,6 +40,8 @@ import org.orbisgis.commons.annotations.NotNull;
 import org.orbisgis.commons.annotations.Nullable;
 import org.orbisgis.orbisdata.processmanager.api.check.ICheckOptionBuilder;
 import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of the {@link ICheckOptionBuilder} interface.
@@ -48,6 +50,11 @@ import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck;
  * @author Sylvain PALOMINOS (UBS 2019-2020)
  */
 public class CheckOptionBuilder implements ICheckOptionBuilder {
+
+    /**
+     * Class logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(CheckOptionBuilder.class);
 
     /**
      * {@link IProcessCheck} being built
@@ -59,35 +66,75 @@ public class CheckOptionBuilder implements ICheckOptionBuilder {
      *
      * @param processCheck {@link IProcessCheck} to build.
      */
-    public CheckOptionBuilder(IProcessCheck processCheck) {
+    protected CheckOptionBuilder(@NotNull IProcessCheck processCheck) {
         this.processCheck = processCheck;
     }
 
     @NotNull
     @Override
     public ICheckOptionBuilder stopOnFail(@Nullable String message) {
-        processCheck.onFail(IProcessCheck.STOP, message);
+        if(message == null) {
+            LOGGER.warn("No message provided for the ProcessCheck stopOnFail.");
+        }
+        processCheck.onFail(IProcessCheck.Action.STOP, message);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public ICheckOptionBuilder stopOnFail() {
+        processCheck.onFail(IProcessCheck.Action.STOP, null);
         return this;
     }
 
     @NotNull
     @Override
     public ICheckOptionBuilder stopOnSuccess(@Nullable String message) {
-        processCheck.onSuccess(IProcessCheck.STOP, message);
+        if(message == null) {
+            LOGGER.warn("No message provided for the ProcessCheck stopOnSuccess.");
+        }
+        processCheck.onSuccess(IProcessCheck.Action.STOP, message);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public ICheckOptionBuilder stopOnSuccess() {
+        processCheck.onSuccess(IProcessCheck.Action.STOP, null);
         return this;
     }
 
     @NotNull
     @Override
     public ICheckOptionBuilder continueOnFail(@Nullable String message) {
-        processCheck.onFail(IProcessCheck.CONTINUE, message);
+        if(message == null) {
+            LOGGER.warn("No message provided for the ProcessCheck continueOnFail.");
+        }
+        processCheck.onFail(IProcessCheck.Action.CONTINUE, message);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public ICheckOptionBuilder continueOnFail() {
+        processCheck.onFail(IProcessCheck.Action.CONTINUE, null);
         return this;
     }
 
     @NotNull
     @Override
     public ICheckOptionBuilder continueOnSuccess(@Nullable String message) {
-        processCheck.onSuccess(IProcessCheck.CONTINUE, message);
+        if(message == null) {
+            LOGGER.warn("No message provided for the ProcessCheck continueOnSuccess.");
+        }
+        processCheck.onSuccess(IProcessCheck.Action.CONTINUE, message);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public ICheckOptionBuilder continueOnSuccess() {
+        processCheck.onSuccess(IProcessCheck.Action.CONTINUE, null);
         return this;
     }
 }

--- a/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/check/ProcessCheck.java
+++ b/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/check/ProcessCheck.java
@@ -133,21 +133,21 @@ public class ProcessCheck implements IProcessCheck, GroovyObject {
                     .map(input -> (IInput)input)
                     .collect(Collectors.toList());
             //Then check that the default values are the same as the data in the given map
-            result = inputs.stream().allMatch(in -> in.getName().isPresent() &&
-                    in.getDefaultValue().isPresent() &&
-                    data.containsKey(in.getName().get()) &&
-                    data.get(in.getName().get()).equals(in.getDefaultValue().get()));
+            result = inputs.stream().allMatch(in -> in.getName() != null &&
+                    in.getDefaultValue() != null &&
+                    data.containsKey(in.getName()) &&
+                    data.get(in.getName()).equals(in.getDefaultValue()));
         }
         else {
             LinkedList<Object> dataList = new LinkedList<>();
             //Gather all the data (process output or input data)
             for (IInOutPut inOutPut : inOutPuts) {
-                if (inOutPut.getProcess().isPresent() &&
-                        inOutPut.getProcess().get().getOutputs().stream()
+                if (inOutPut.getProcess() != null &&
+                        inOutPut.getProcess().getOutputs().stream()
                                 .anyMatch(output -> output.getName().equals(inOutPut.getName()))) {
-                    dataList.add(inOutPut.getProcess().get().getResults().get(inOutPut.getName().get()));
-                } else if (data != null && inOutPut.getName().isPresent()) {
-                    dataList.add(data.get(inOutPut.getName().get()));
+                    dataList.add(inOutPut.getProcess().getResults().get(inOutPut.getName()));
+                } else if (data != null && inOutPut.getName() != null) {
+                    dataList.add(data.get(inOutPut.getName()));
                 }
             }
             //Execute the Closure with the gathered data.

--- a/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/check/ProcessCheck.java
+++ b/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/check/ProcessCheck.java
@@ -46,10 +46,10 @@ import org.orbisgis.orbisdata.processmanager.api.IProcess;
 import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck;
 import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
 import org.orbisgis.orbisdata.processmanager.api.inoutput.IInput;
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.swing.text.html.Option;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -205,17 +205,9 @@ public class ProcessCheck implements IProcessCheck, GroovyObject {
     }
 
     @Override
-    public void setInOutPuts(@Nullable List<IInOutPut> data) {
-        if(data != null) {
-            this.inOutPuts.clear();
-            this.inOutPuts.addAll(data);
-        }
-    }
-
-    @Override
     @NotNull
-    public Optional<LinkedList<IInOutPut>> getInOutPuts() {
-        return Optional.ofNullable(inOutPuts);
+    public LinkedList<IInOutPut> getInOutPuts() {
+        return inOutPuts;
     }
 
     @Override
@@ -313,5 +305,44 @@ public class ProcessCheck implements IProcessCheck, GroovyObject {
     @Override
     public void setMetaClass(@Nullable MetaClass metaClass) {
         this.metaClass = metaClass;
+    }
+
+    @Override
+    @NotNull
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("ProcessCheck : \n");
+        if(!getClosure().isPresent() && getInOutPuts().isEmpty()){
+            return "No check can be run as there is no closure nor in/outputs set.";
+        }
+        if(getProcess().isPresent()) {
+            //If there is a process, get the name. If the name is null, use the process id.
+            String processName = getProcess().get().getTitle() != null ?
+                    getProcess().get().getTitle() :
+                    getProcess().get().getIdentifier();
+            builder.append("On process :")
+                    .append(processName)
+                    .append("\n");
+        }
+        if(!getInOutPuts().isEmpty()) {
+            builder.append("Check that inputs :\n");
+            inOutPuts.stream()
+                    .filter(inOutPut -> inOutPut instanceof IInput)
+                    .forEach(inOutPut -> builder.append("\t").append(inOutPut.getName()).append("\n"));
+
+            if (getProcess().isPresent()) {
+                builder.append("and output :\n");
+                inOutPuts.stream()
+                        .filter(inOutPut -> inOutPut instanceof IOutput)
+                        .forEach(inOutPut -> builder.append("\t").append(inOutPut.getName()).append("\n"));
+            }
+        }
+        if (getClosure().isPresent()) {
+            builder.append("Verifies a closure");
+        }
+        else {
+            builder.append("are equals to provided data.");
+        }
+        return builder.toString();
     }
 }

--- a/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/inoutput/Input.java
+++ b/process-manager/process/src/main/java/org/orbisgis/orbisdata/processmanager/process/inoutput/Input.java
@@ -60,7 +60,7 @@ public class Input extends InOutPut implements IInput {
      * @param process {@link IProcess} of the input/output.
      * @param name    Name of the input/output.
      */
-    public Input(@Nullable IProcess process, @NotNull String name) {
+    public Input(@Nullable IProcess process, @Nullable String name) {
         super(process, name);
     }
 

--- a/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckClosureBuilder.groovy
+++ b/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckClosureBuilder.groovy
@@ -24,7 +24,7 @@
  * version.
  *
  * ProcessManager is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * WARRANTY without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with
@@ -34,41 +34,43 @@
  * or contact directly:
  * info_at_ orbisgis.org
  */
-package org.orbisgis.orbisdata.processmanager.process.check;
+package org.orbisgis.orbisdata.processmanager.process.check
 
-import groovy.lang.Closure;
-import org.orbisgis.commons.annotations.NotNull;
-import org.orbisgis.commons.annotations.Nullable;
-import org.orbisgis.orbisdata.processmanager.api.check.ICheckClosureBuilder;
-import org.orbisgis.orbisdata.processmanager.api.check.ICheckOptionBuilder;
-import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck;
+import groovy.lang.Closure
+import org.junit.jupiter.api.Test
+import org.orbisgis.commons.annotations.NotNull
+import org.orbisgis.commons.annotations.Nullable
+import org.orbisgis.orbisdata.processmanager.api.IProcess
+import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut
+
+import java.util.LinkedHashMap
+import java.util.Optional
+
+import static org.junit.jupiter.api.Assertions.*
 
 /**
- * Implementation of the {@link ICheckClosureBuilder} interface.
+ * Test class dedicated to {@link CheckClosureBuilder} class.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2019-2020)
+ * @author Sylvain PALOMINOS (UBS 2020)
  */
-public class CheckClosureBuilder implements ICheckClosureBuilder {
+class TestCheckClosureBuilder {
 
     /**
-     * {@link IProcessCheck} being built
+     * Test the {@link CheckClosureBuilder#check(Closure)} method.
      */
-    private final IProcessCheck processCheck;
+    @Test
+    void checkTest() {
+        def dummy = new DummyProcessCheck()
+        def builder = new CheckClosureBuilder(dummy)
+        def cl = {}
+        assert builder.check(cl)
+        assert cl == dummy.closure.get()
 
-    /**
-     * Default constructor.
-     *
-     * @param processCheck {@link IProcessCheck} to build.
-     */
-    protected CheckClosureBuilder(@NotNull IProcessCheck processCheck) {
-        this.processCheck = processCheck;
-    }
-
-    @Override
-    @NotNull
-    public ICheckOptionBuilder check(@Nullable Closure<?> cl) {
-        processCheck.setClosure(cl);
-        return new CheckOptionBuilder(processCheck);
+        dummy = new DummyProcessCheck()
+        builder = new CheckClosureBuilder(dummy)
+        assert builder.check()
+        assert !dummy.closure.isPresent()
     }
 }

--- a/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckClosureBuilder.groovy
+++ b/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckClosureBuilder.groovy
@@ -36,19 +36,8 @@
  */
 package org.orbisgis.orbisdata.processmanager.process.check
 
-import groovy.lang.Closure
+
 import org.junit.jupiter.api.Test
-import org.orbisgis.commons.annotations.NotNull
-import org.orbisgis.commons.annotations.Nullable
-import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck
-import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut
-
-import java.util.LinkedHashMap
-import java.util.Optional
-
-import static org.junit.jupiter.api.Assertions.*
-
 /**
  * Test class dedicated to {@link CheckClosureBuilder} class.
  *
@@ -64,13 +53,13 @@ class TestCheckClosureBuilder {
     void checkTest() {
         def dummy = new DummyProcessCheck()
         def builder = new CheckClosureBuilder(dummy)
-        def cl = {}
+        def cl = { }
         assert builder.check(cl)
         assert cl == dummy.closure.get()
 
         dummy = new DummyProcessCheck()
         builder = new CheckClosureBuilder(dummy)
         assert builder.check()
-        assert !dummy.closure.isPresent()
+        assert !dummy.closure.present
     }
 }

--- a/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckDataBuilder.groovy
+++ b/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckDataBuilder.groovy
@@ -1,0 +1,85 @@
+/*
+ * Bundle ProcessManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * ProcessManager is distributed under LGPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * ProcessManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * ProcessManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General License for more details.
+ *
+ * You should have received a copy of the GNU General License along with
+ * ProcessManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.orbisdata.processmanager.process.check
+
+import org.junit.jupiter.api.Test
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut
+import org.orbisgis.orbisdata.processmanager.process.inoutput.Input
+import org.orbisgis.orbisdata.processmanager.process.inoutput.Output
+
+/**
+ * Test class dedicated to {@link CheckClosureBuilder} class.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2020)
+ */
+class TestCheckDataBuilder {
+
+    /**
+     * Test the {@link CheckDataBuilder#with(IInOutPut...)} method.
+     */
+    @Test
+    void withTest() {
+        def (in1, in2) = [new Input(), new Input()]
+        def (out1, out2) = [new Output(), new Output()]
+
+        def dummy = new DummyProcessCheck()
+        def builder = new CheckDataBuilder(dummy)
+        assert builder.with(in1, in2, out1, out2)
+        assert [in1, in2, out1, out2], dummy.inputOrOutput
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckDataBuilder(dummy)
+        assert builder.with(out2)
+        assert [out2], dummy.inputOrOutput
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckDataBuilder(dummy)
+        assert builder.with()
+        assert !dummy.inputOrOutput
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckDataBuilder(dummy)
+        assert builder.with()
+        assert !dummy.inputOrOutput
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckDataBuilder(dummy)
+        assert builder.with()
+        assert !dummy.inputOrOutput
+    }
+}

--- a/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckDataBuilder.groovy
+++ b/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckDataBuilder.groovy
@@ -60,12 +60,12 @@ class TestCheckDataBuilder {
         def dummy = new DummyProcessCheck()
         def builder = new CheckDataBuilder(dummy)
         assert builder.with(in1, in2, out1, out2)
-        assert [in1, in2, out1, out2], dummy.inputOrOutput
+        assert [in1, in2, out1, out2] == dummy.inputOrOutput
 
         dummy = new DummyProcessCheck()
         builder = new CheckDataBuilder(dummy)
         assert builder.with(out2)
-        assert [out2], dummy.inputOrOutput
+        assert [out2] == dummy.inputOrOutput
 
         dummy = new DummyProcessCheck()
         builder = new CheckDataBuilder(dummy)

--- a/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckOptionBuilder.groovy
+++ b/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckOptionBuilder.groovy
@@ -1,0 +1,178 @@
+/*
+ * Bundle ProcessManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * ProcessManager is distributed under LGPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * ProcessManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * ProcessManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General License for more details.
+ *
+ * You should have received a copy of the GNU General License along with
+ * ProcessManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.orbisdata.processmanager.process.check
+
+import org.junit.jupiter.api.Test
+
+import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.CONTINUE
+import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.STOP
+/**
+ * Test class dedicated to {@link CheckOptionBuilder} class.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2019-2020)
+ */
+class TestCheckOptionBuilder {
+
+    /**
+     * Test the {@link CheckOptionBuilder#stopOnFail()}, {@link CheckOptionBuilder#stopOnFail(String)},
+     * {@link CheckOptionBuilder#continueOnFail()}, {@link CheckOptionBuilder#continueOnFail(String)}methods.
+     */
+    @Test
+    void onFailTest() {
+        def failMessage = "Fail Message"
+        def successMessage = "Success Message"
+
+        def dummy = new DummyProcessCheck()
+        def builder = new CheckOptionBuilder(dummy)
+        assert builder.stopOnFail()
+        assert STOP == dummy.failAction
+        assert !dummy.failMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.stopOnFail(failMessage)
+        assert STOP == dummy.failAction
+        assert failMessage == dummy.failMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.stopOnFail()
+        assert STOP == dummy.failAction
+        assert !dummy.failMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.stopOnFail()
+        assert STOP == dummy.failAction
+        assert !dummy.failMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.stopOnFail()
+        assert STOP == dummy.failAction
+        assert !dummy.failMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.continueOnFail(successMessage)
+        assert CONTINUE == dummy.failAction
+        assert successMessage == dummy.failMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.continueOnFail()
+        assert CONTINUE == dummy.failAction
+        assert !dummy.failMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.continueOnFail()
+        assert CONTINUE == dummy.failAction
+        assert !dummy.failMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.continueOnFail()
+        assert CONTINUE == dummy.failAction
+        assert !dummy.failMessage
+    }
+
+    /**
+     * Test the {@link CheckOptionBuilder#stopOnSuccess()}, {@link CheckOptionBuilder#stopOnSuccess(String)},
+     * {@link CheckOptionBuilder#continueOnSuccess()}, {@link CheckOptionBuilder#continueOnSuccess(String)}methods.
+     */
+    @Test
+    void onSuccessTest() {
+        def failMessage = "Fail Message"
+        def successMessage = "Success Message"
+
+        def dummy = new DummyProcessCheck()
+        def builder = new CheckOptionBuilder(dummy)
+        assert builder.stopOnSuccess()
+        assert STOP == dummy.successAction
+        assert !dummy.successMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.stopOnSuccess(failMessage)
+        assert STOP == dummy.successAction
+        assert failMessage, dummy.successMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.stopOnSuccess()
+        assert STOP == dummy.successAction
+        assert !dummy.successMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.stopOnSuccess()
+        assert STOP == dummy.successAction
+        assert !dummy.successMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.stopOnSuccess()
+        assert STOP == dummy.successAction
+        assert !dummy.successMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.continueOnSuccess(successMessage)
+        assert CONTINUE == dummy.successAction
+        assert successMessage == dummy.successMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.continueOnSuccess()
+        assert CONTINUE == dummy.successAction
+        assert !dummy.successMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.continueOnSuccess()
+        assert CONTINUE == dummy.successAction
+        assert !dummy.successMessage
+
+        dummy = new DummyProcessCheck()
+        builder = new CheckOptionBuilder(dummy)
+        assert builder.continueOnSuccess()
+        assert CONTINUE == dummy.successAction
+        assert !dummy.successMessage
+    }
+}

--- a/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckOptionBuilder.groovy
+++ b/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestCheckOptionBuilder.groovy
@@ -36,10 +36,11 @@
  */
 package org.orbisgis.orbisdata.processmanager.process.check
 
-import org.junit.jupiter.api.Test
-
 import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.CONTINUE
 import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.STOP
+
+import org.junit.jupiter.api.Test
+
 /**
  * Test class dedicated to {@link CheckOptionBuilder} class.
  *

--- a/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestProcessCheck.groovy
+++ b/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestProcessCheck.groovy
@@ -36,7 +36,7 @@
  */
 package org.orbisgis.orbisdata.processmanager.process.check
 
-
+import org.codehaus.groovy.runtime.InvokerHelper
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.orbisgis.commons.annotations.Nullable
@@ -47,6 +47,28 @@ import org.orbisgis.orbisdata.processmanager.process.ProcessManager
 import org.orbisgis.orbisdata.processmanager.process.inoutput.Input
 import org.orbisgis.orbisdata.processmanager.process.inoutput.Output
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.*
 /**
  * Test class dedicated to {@link ProcessCheck} class.
@@ -268,5 +290,53 @@ class TestProcessCheck {
         processCheck.closure = {out1 -> return out1 == 'abc'}
         processCheck.inOutPuts = [new Output(PROCESS, "out1")]
         assert !processCheck.run(mapInputs)
+    }
+
+    /**
+     * Test the {@link ProcessCheck#setProperty(String, Object)}, {@link ProcessCheck#getProperty(String)} methods.
+     */
+    @Test
+    void propertyTest() {
+        def processCheck = new ProcessCheck(PROCESS)
+
+        processCheck.inOutPuts == null
+        def obj = processCheck.inOutPuts
+        assert  obj !instanceof Optional
+        assert  obj instanceof LinkedList
+        assert  obj.isEmpty()
+
+        processCheck.inOutPuts = [new Input()]
+        obj = processCheck.inOutPuts
+        assert  obj !instanceof Optional
+        assert  obj instanceof LinkedList
+        assert 1 == obj.size()
+
+        obj = processCheck.inOutPuts
+        assert obj
+
+        processCheck.metaClass = InvokerHelper.getMetaClass(getClass())
+        obj = processCheck.metaClass
+        assert obj
+
+        processCheck.metaClass = null
+        processCheck.inOutPuts = null
+        obj = processCheck.inOutPuts
+        assert  !obj
+    }
+
+    /**
+     * Test the {@link ProcessCheck#invokeMethod(String, Object)} methods.
+     */
+    @Test
+    void invokeMethodTest() {
+        def processCheck = new ProcessCheck(PROCESS)
+
+        assert !processCheck.invokeMethod(null, "value")
+        assert !processCheck.invokeMethod(null, null)
+        assert !processCheck.invokeMethod("setClosure", null)
+        assert !processCheck.invokeMethod("getClosure", null)
+
+        assert !processCheck.invokeMethod("setClosure", {in1, in2, in3 -> return in1+in2+in3 == 'abc'})
+        assert processCheck.invokeMethod("getClosure", null)
     }
 }

--- a/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestProcessCheck.groovy
+++ b/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestProcessCheck.groovy
@@ -1,0 +1,272 @@
+/*
+ * Bundle ProcessManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * ProcessManager is distributed under LGPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * ProcessManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * ProcessManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General License for more details.
+ *
+ * You should have received a copy of the GNU General License along with
+ * ProcessManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.orbisdata.processmanager.process.check
+
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.orbisgis.commons.annotations.Nullable
+import org.orbisgis.orbisdata.processmanager.api.IProcess
+import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut
+import org.orbisgis.orbisdata.processmanager.process.ProcessManager
+import org.orbisgis.orbisdata.processmanager.process.inoutput.Input
+import org.orbisgis.orbisdata.processmanager.process.inoutput.Output
+
+import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.*
+/**
+ * Test class dedicated to {@link ProcessCheck} class.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2020)
+ */
+class TestProcessCheck {
+
+    private static IProcess PROCESS
+
+    @Nullable
+    private static IProcess NULL_PROCESS
+
+    @BeforeAll
+    static void beforeAll() {
+        PROCESS = ProcessManager.createFactory()
+                .create {
+                        outputs "out1": String
+                        inputs "in1": String, "in2": String, "in3": String
+                        run {in1, in2, in3 -> return [out1:in1+in2+in3]} }
+        NULL_PROCESS = null
+    }
+
+    @Test
+    void getProcessTest() {
+        assert new ProcessCheck(PROCESS).process
+        assert !new ProcessCheck(NULL_PROCESS).process
+    }
+
+    /**
+     * Test the {@link ProcessCheck#fail()}, {@link ProcessCheck#success()},
+     * {@link ProcessCheck#onFail(String)}, {@link ProcessCheck#onFail(IProcessCheck.Action, String)},
+     * {@link ProcessCheck#onSuccess(String)}, {@link ProcessCheck#onSuccess(IProcessCheck.Action, String)} methods.
+     */
+    @Test
+    void failSuccessTest() {
+        def message = "message"
+        def check = new ProcessCheck(PROCESS)
+
+        assert check.fail()
+        assert !check.success()
+
+        check.onFail(null, message)
+        assert check.fail()
+        check.onFail(null, null)
+        assert check.fail()
+        check.onFail(STOP, message)
+        assert check.fail()
+        check.onFail(STOP, null)
+        assert check.fail()
+        check.onFail(CONTINUE, message)
+        assert !check.fail()
+        check.onFail(CONTINUE, null)
+        assert !check.fail()
+        check.onFail(message)
+        assert check.fail()
+        check.onFail(null)
+        assert check.fail()
+
+        check.onSuccess(null, message)
+        assert check.success()
+        check.onSuccess(null, null)
+        assert check.success()
+        check.onSuccess(STOP, message)
+        assert check.success()
+        check.onSuccess(STOP, null)
+        assert check.success()
+        check.onSuccess(CONTINUE, message)
+        assert !check.success()
+        check.onSuccess(CONTINUE, null)
+        assert !check.success()
+        check.onSuccess(message)
+        assert !check.success()
+        check.onSuccess(null)
+        assert !check.success()
+    }
+
+    /**
+     * Test the {@link ProcessCheck#run(LinkedHashMap)}, {@link ProcessCheck#setClosure(Closure)},
+     * {@link ProcessCheck#setInOutPuts(IInOutPut...)} methods.
+     */
+    @Test
+    void runTest() {
+        def map = [in1: "a", in2: "b"]
+        def cl = {in1, in2, in3 -> return in1+in2+in3 == 'abc'}
+
+        def emptyInOutPuts = []
+        def inOutPuts = [
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(PROCESS, "in2"),
+                new Input(PROCESS, "in3").optional("c")]
+
+        def processCheck = new ProcessCheck(PROCESS)
+
+        //Ensure the check is not run
+        processCheck.onFail(STOP, null)
+        processCheck.onSuccess(STOP, null)
+
+        processCheck.closure = null
+        processCheck.inOutPuts = null
+        assert !processCheck.run()
+        assert !processCheck.run([:])
+        assert !processCheck.run(map)
+
+        processCheck.closure = null
+        processCheck.inOutPuts = emptyInOutPuts
+        assert !processCheck.run()
+        assert !processCheck.run([:])
+        assert !processCheck.run(map)
+
+        processCheck.closure = null
+        processCheck.inOutPuts = inOutPuts
+        assert !processCheck.run()
+        assert !processCheck.run([:])
+        assert processCheck.run(map)
+
+        processCheck.closure = cl
+        processCheck.inOutPuts = null
+        assert processCheck.run()
+        assert processCheck.run([:])
+        assert processCheck.run(map)
+
+        processCheck.closure = cl
+        processCheck.inOutPuts = emptyInOutPuts
+        assert processCheck.run()
+        assert processCheck.run([:])
+        assert processCheck.run(map)
+
+        processCheck.closure = cl
+        processCheck.inOutPuts = inOutPuts
+        assert processCheck.run()
+        assert processCheck.run([:])
+        assert processCheck.run(map)
+
+
+        //Test that check without closure fail when required
+        def inOutPutsOpt = [
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(PROCESS, "in2").optional("b"),
+                new Input(PROCESS, "in3").optional("c"),
+                new Output(PROCESS, "out1")]
+        def noNameInOutPuts = [
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(PROCESS, null).optional("b"),
+                new Input(PROCESS, null).optional("c"),
+                new Output(PROCESS, "out1")]
+
+        def mapMissingInputs = [in1: "a"]
+        def mapInvalidInputs = [in1: "a", in2: "a", in3: "a"]
+        def mapInputs = [in1: "a", in2: "b", in3: "c"]
+
+        processCheck.onFail(STOP, null)
+        processCheck.onSuccess(CONTINUE, null)
+
+        processCheck.closure = null
+        processCheck.inOutPuts = noNameInOutPuts
+        assert processCheck.run(map)
+
+        processCheck.closure = null
+        processCheck.inOutPuts = inOutPuts
+        assert processCheck.run(mapInputs)
+
+        processCheck.closure = null
+        processCheck.inOutPuts = inOutPutsOpt
+        assert processCheck.run(mapMissingInputs)
+
+        processCheck.closure = null
+        processCheck.inOutPuts = inOutPutsOpt
+        assert processCheck.run(mapInvalidInputs)
+
+
+        //Test that check with closure fail when required
+        def inOutPutsNullProcess = [
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(null, "in2").optional("b"),
+                new Input(PROCESS, "in3").optional("c"),
+                new Output(PROCESS, "out1")]
+
+        processCheck.closure = cl
+        processCheck.inOutPuts = inOutPutsNullProcess
+        assert processCheck.run(mapInputs)
+
+        processCheck.closure = cl
+        processCheck.inOutPuts = noNameInOutPuts
+        assert processCheck.run(mapInputs)
+
+        processCheck.closure = cl
+        processCheck.inOutPuts = noNameInOutPuts
+        assert processCheck.run(null)
+
+        processCheck.closure = cl
+        processCheck.inOutPuts = inOutPuts
+        assert processCheck.run(mapInvalidInputs)
+
+        processCheck.closure = {in1, in2, in3 -> return in1+in2+in3}
+        processCheck.inOutPuts = inOutPuts
+        assert processCheck.run(mapInputs)
+
+        processCheck.closure = {in1, in2, in3 -> return false}
+        processCheck.inOutPuts = inOutPuts
+        assert processCheck.run(mapInputs)
+
+        processCheck.closure = null
+        processCheck.inOutPuts = [
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(PROCESS, "in2").optional("b"),
+                new Input(PROCESS, "in3").optional("c")]
+        assert !processCheck.run(mapInputs)
+
+        processCheck.closure = cl
+        processCheck.inOutPuts = [
+                new Input(PROCESS, "in1"),
+                new Input(PROCESS, "in2"),
+                new Input(PROCESS, "in3")]
+        assert !processCheck.run(mapInputs)
+
+        assert PROCESS.execute(mapInputs)
+        processCheck.closure = {out1 -> return out1 == 'abc'}
+        processCheck.inOutPuts = [new Output(PROCESS, "out1")]
+        assert !processCheck.run(mapInputs)
+    }
+}

--- a/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestProcessCheck.groovy
+++ b/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestProcessCheck.groovy
@@ -36,6 +36,9 @@
  */
 package org.orbisgis.orbisdata.processmanager.process.check
 
+import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.CONTINUE
+import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.STOP
+
 import org.codehaus.groovy.runtime.InvokerHelper
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -46,9 +49,6 @@ import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut
 import org.orbisgis.orbisdata.processmanager.process.ProcessManager
 import org.orbisgis.orbisdata.processmanager.process.inoutput.Input
 import org.orbisgis.orbisdata.processmanager.process.inoutput.Output
-
-import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.CONTINUE
-import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.STOP
 /**
  * Test class dedicated to {@link ProcessCheck} class.
  *

--- a/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestProcessCheck.groovy
+++ b/process-manager/process/src/test/groovy/org/orbisgis/orbisdata/processmanager/process/check/TestProcessCheck.groovy
@@ -47,29 +47,8 @@ import org.orbisgis.orbisdata.processmanager.process.ProcessManager
 import org.orbisgis.orbisdata.processmanager.process.inoutput.Input
 import org.orbisgis.orbisdata.processmanager.process.inoutput.Output
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow
-import static org.junit.jupiter.api.Assertions.assertEquals
-import static org.junit.jupiter.api.Assertions.assertFalse
-import static org.junit.jupiter.api.Assertions.assertFalse
-import static org.junit.jupiter.api.Assertions.assertNotNull
-import static org.junit.jupiter.api.Assertions.assertNotNull
-import static org.junit.jupiter.api.Assertions.assertNotNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.*
+import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.CONTINUE
+import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.STOP
 /**
  * Test class dedicated to {@link ProcessCheck} class.
  *

--- a/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/CheckClosureBuilderTest.java
+++ b/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/CheckClosureBuilderTest.java
@@ -37,38 +37,40 @@
 package org.orbisgis.orbisdata.processmanager.process.check;
 
 import groovy.lang.Closure;
+import org.junit.jupiter.api.Test;
 import org.orbisgis.commons.annotations.NotNull;
 import org.orbisgis.commons.annotations.Nullable;
-import org.orbisgis.orbisdata.processmanager.api.check.ICheckClosureBuilder;
-import org.orbisgis.orbisdata.processmanager.api.check.ICheckOptionBuilder;
+import org.orbisgis.orbisdata.processmanager.api.IProcess;
 import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck;
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
+
+import java.util.LinkedHashMap;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Implementation of the {@link ICheckClosureBuilder} interface.
+ * Test class dedicated to {@link CheckClosureBuilder} class.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2019-2020)
+ * @author Sylvain PALOMINOS (UBS 2020)
  */
-public class CheckClosureBuilder implements ICheckClosureBuilder {
+public class CheckClosureBuilderTest {
 
     /**
-     * {@link IProcessCheck} being built
+     * Test the {@link CheckClosureBuilder#check(Closure)} method.
      */
-    private final IProcessCheck processCheck;
+    @Test
+    public void checkTest() {
+        DummyProcessCheck dummy = new DummyProcessCheck(null);
+        CheckClosureBuilder builder = new CheckClosureBuilder(dummy);
+        Closure<?> cl = new Closure<Object>(this) {};
+        assertNotNull(builder.check(cl));
+        assertEquals(cl, dummy.closure);
 
-    /**
-     * Default constructor.
-     *
-     * @param processCheck {@link IProcessCheck} to build.
-     */
-    protected CheckClosureBuilder(@NotNull IProcessCheck processCheck) {
-        this.processCheck = processCheck;
-    }
-
-    @Override
-    @NotNull
-    public ICheckOptionBuilder check(@Nullable Closure<?> cl) {
-        processCheck.setClosure(cl);
-        return new CheckOptionBuilder(processCheck);
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckClosureBuilder(dummy);
+        assertNotNull(builder.check(null));
+        assertNull(dummy.closure);
     }
 }

--- a/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/CheckClosureBuilderTest.java
+++ b/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/CheckClosureBuilderTest.java
@@ -38,14 +38,6 @@ package org.orbisgis.orbisdata.processmanager.process.check;
 
 import groovy.lang.Closure;
 import org.junit.jupiter.api.Test;
-import org.orbisgis.commons.annotations.NotNull;
-import org.orbisgis.commons.annotations.Nullable;
-import org.orbisgis.orbisdata.processmanager.api.IProcess;
-import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck;
-import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
-
-import java.util.LinkedHashMap;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/CheckDataBuilderTest.java
+++ b/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/CheckDataBuilderTest.java
@@ -1,0 +1,90 @@
+/*
+ * Bundle ProcessManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * ProcessManager is distributed under LGPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * ProcessManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * ProcessManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * ProcessManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.orbisdata.processmanager.process.check;
+
+import org.junit.jupiter.api.Test;
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
+import org.orbisgis.orbisdata.processmanager.process.inoutput.InOutPut;
+import org.orbisgis.orbisdata.processmanager.process.inoutput.Input;
+import org.orbisgis.orbisdata.processmanager.process.inoutput.Output;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class dedicated to {@link CheckClosureBuilder} class.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2020)
+ */
+public class CheckDataBuilderTest {
+
+    /**
+     * Test the {@link CheckDataBuilder#with(IInOutPut...)} method.
+     */
+    @Test
+    public void withTest() {
+        Input in1 = new Input();
+        Input in2 = new Input();
+        Output out1 = new Output();
+        Output out2 = new Output();
+
+        DummyProcessCheck dummy = new DummyProcessCheck(null);
+        CheckDataBuilder builder = new CheckDataBuilder(dummy);
+        assertNotNull(builder.with(in1, in2, out1, out2));
+        assertArrayEquals(new InOutPut[]{in1, in2, out1, out2}, dummy.inputOrOutput);
+
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckDataBuilder(dummy);
+        assertNotNull(builder.with(out2));
+        assertArrayEquals(new InOutPut[]{out2}, dummy.inputOrOutput);
+
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckDataBuilder(dummy);
+        assertNotNull(builder.with((IInOutPut[]) null));
+        assertNull(dummy.inputOrOutput);
+
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckDataBuilder(dummy);
+        assertNotNull(builder.with((IInOutPut) null));
+        assertNull(dummy.inputOrOutput);
+
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckDataBuilder(dummy);
+        assertNotNull(builder.with());
+        assertNull(dummy.inputOrOutput);
+    }
+}

--- a/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/CheckOptionBuilderTest.java
+++ b/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/CheckOptionBuilderTest.java
@@ -36,18 +36,8 @@
  */
 package org.orbisgis.orbisdata.processmanager.process.check;
 
-import groovy.lang.Closure;
-import groovy.lang.GroovyShell;
 import org.junit.jupiter.api.Test;
-import org.orbisgis.orbisdata.processmanager.api.check.ICheckClosureBuilder;
-import org.orbisgis.orbisdata.processmanager.api.check.ICheckDataBuilder;
-import org.orbisgis.orbisdata.processmanager.api.check.ICheckOptionBuilder;
 import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck;
-import org.orbisgis.orbisdata.processmanager.process.Process;
-import org.orbisgis.orbisdata.processmanager.process.ProcessManager;
-import org.orbisgis.orbisdata.processmanager.process.ProcessMapper;
-
-import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -55,115 +45,135 @@ import static org.junit.jupiter.api.Assertions.*;
  * Test class dedicated to {@link CheckOptionBuilder} class.
  *
  * @author Erwan Bocher (CNRS)
- * @author Sylvain PALOMINOS (UBS 2019)
+ * @author Sylvain PALOMINOS (UBS 2019-2020)
  */
 public class CheckOptionBuilderTest {
 
     /**
-     * Test the building of the check options.
+     * Test the {@link CheckOptionBuilder#stopOnFail()}, {@link CheckOptionBuilder#stopOnFail(String)},
+     * {@link CheckOptionBuilder#continueOnFail()}, {@link CheckOptionBuilder#continueOnFail(String)}methods.
      */
     @Test
-    public void buildingTest() {
-        ICheckDataBuilder dataBuilder = new ProcessMapper().after(null);
-        assertNotNull(dataBuilder);
+    public void onFailTest() {
+        String failMessage = "Fail Message";
+        String successMessage = "Success Message";
 
-        ICheckClosureBuilder closureBuilder = dataBuilder.with("toto", "tata");
-        assertNotNull(closureBuilder);
+        DummyProcessCheck dummy = new DummyProcessCheck(null);
+        CheckOptionBuilder builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.stopOnFail());
+        assertEquals(IProcessCheck.Action.STOP, dummy.failAction);
+        assertNull(dummy.failMessage);
 
-        ICheckOptionBuilder optionBuilder = closureBuilder.check((Closure) new GroovyShell().evaluate("({true})"));
-        assertNotNull(optionBuilder);
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.stopOnFail(failMessage));
+        assertEquals(IProcessCheck.Action.STOP, dummy.failAction);
+        assertEquals(failMessage, dummy.failMessage);
 
-        optionBuilder = optionBuilder.continueOnFail("continue");
-        assertNotNull(optionBuilder);
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.stopOnFail());
+        assertEquals(IProcessCheck.Action.STOP, dummy.failAction);
+        assertNull(dummy.failMessage);
 
-        optionBuilder = optionBuilder.continueOnSuccess("continue");
-        assertNotNull(optionBuilder);
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.stopOnFail(null));
+        assertEquals(IProcessCheck.Action.STOP, dummy.failAction);
+        assertNull(dummy.failMessage);
 
-        optionBuilder = optionBuilder.stopOnFail("continue");
-        assertNotNull(optionBuilder);
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.stopOnFail());
+        assertEquals(IProcessCheck.Action.STOP, dummy.failAction);
+        assertNull(dummy.failMessage);
 
-        optionBuilder = optionBuilder.stopOnSuccess("continue");
-        assertNotNull(optionBuilder);
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.continueOnFail(successMessage));
+        assertEquals(IProcessCheck.Action.CONTINUE, dummy.failAction);
+        assertEquals(successMessage, dummy.failMessage);
+
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.continueOnFail());
+        assertEquals(IProcessCheck.Action.CONTINUE, dummy.failAction);
+        assertNull(dummy.failMessage);
+
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.continueOnFail(null));
+        assertEquals(IProcessCheck.Action.CONTINUE, dummy.failAction);
+        assertNull(dummy.failMessage);
+
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.continueOnFail());
+        assertEquals(IProcessCheck.Action.CONTINUE, dummy.failAction);
+        assertNull(dummy.failMessage);
     }
 
     /**
-     * Test the {@link ProcessCheck} class.
+     * Test the {@link CheckOptionBuilder#stopOnSuccess()}, {@link CheckOptionBuilder#stopOnSuccess(String)},
+     * {@link CheckOptionBuilder#continueOnSuccess()}, {@link CheckOptionBuilder#continueOnSuccess(String)}methods.
      */
     @Test
-    public void processCheckTest() {
-        ProcessCheck processCheck = new ProcessCheck(null);
-        assertNull(processCheck.getProcess());
+    public void onSuccessTest() {
+        String failMessage = "Fail Message";
+        String successMessage = "Success Message";
 
-        processCheck.setClosure(null);
-        ProcessCheck finalProcessCheck = processCheck;
-        assertThrows(IllegalStateException.class, () -> finalProcessCheck.run(null));
+        DummyProcessCheck dummy = new DummyProcessCheck(null);
+        CheckOptionBuilder builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.stopOnSuccess());
+        assertEquals(IProcessCheck.Action.STOP, dummy.successAction);
+        assertNull(dummy.successMessage);
 
-        processCheck.setClosure((Closure) new GroovyShell().evaluate("({1+1})"));
-        ProcessCheck finalProcessCheck2 = processCheck;
-        assertThrows(IllegalStateException.class, () -> finalProcessCheck2.run(null));
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.stopOnSuccess(failMessage));
+        assertEquals(IProcessCheck.Action.STOP, dummy.successAction);
+        assertEquals(failMessage, dummy.successMessage);
 
-        LinkedHashMap<String, Object> inputs = new LinkedHashMap<>();
-        inputs.put("toto", String.class);
-        LinkedHashMap<String, Object> outputs = new LinkedHashMap<>();
-        outputs.put("tata", String.class);
-        LinkedHashMap<String, Object> data = new LinkedHashMap<>();
-        data.put("toto", "tata");
-        data.put("tata", "toto");
-        Process process = (Process) ProcessManager.createFactory().create().inputs(inputs).outputs(outputs).getProcess();
-        processCheck = new ProcessCheck(process);
-        assertEquals(process.getIdentifier(), processCheck.getProcess().getIdentifier());
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.stopOnSuccess());
+        assertEquals(IProcessCheck.Action.STOP, dummy.successAction);
+        assertNull(dummy.successMessage);
 
-        ProcessCheck finalProcessCheck1 = processCheck;
-        processCheck.onFail(IProcessCheck.CONTINUE, "continue fail");
-        processCheck.fail();
-        processCheck.onFail(IProcessCheck.STOP, "stop fail");
-        assertThrows(IllegalStateException.class, finalProcessCheck1::fail);
-        processCheck.onSuccess(IProcessCheck.STOP, "continue success");
-        assertThrows(IllegalStateException.class, finalProcessCheck1::success);
-        processCheck.onSuccess(IProcessCheck.CONTINUE, "continue success");
-        processCheck.success();
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.stopOnSuccess(null));
+        assertEquals(IProcessCheck.Action.STOP, dummy.successAction);
+        assertNull(dummy.successMessage);
 
-        processCheck.setInOutputs(process.getProperty("toto"), process.getProperty("tata"));
-        processCheck.setClosure((Closure) new GroovyShell().evaluate("({a, b ->b == 'tata'})"));
-        processCheck.run(data);
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.stopOnSuccess());
+        assertEquals(IProcessCheck.Action.STOP, dummy.successAction);
+        assertNull(dummy.successMessage);
 
-        processCheck = new ProcessCheck(process);
-        processCheck.onFail(IProcessCheck.STOP, "stop fail");
-        processCheck.onSuccess(IProcessCheck.CONTINUE, "continue success");
-        processCheck.setInOutputs(process.getProperty("toto"), process.getProperty("tata"));
-        processCheck.setClosure((Closure) new GroovyShell().evaluate("({a, b -> b != 'tata'})"));
-        ProcessCheck finalProcessCheck3 = processCheck;
-        assertThrows(IllegalStateException.class, () -> finalProcessCheck3.run(data));
-    }
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.continueOnSuccess(successMessage));
+        assertEquals(IProcessCheck.Action.CONTINUE, dummy.successAction);
+        assertEquals(successMessage, dummy.successMessage);
 
-    /**
-     * Test fail {@link ProcessCheck} class.
-     */
-    @Test
-    public void failProcessCheckTest() {
-        LinkedHashMap<String, Object> inputs = new LinkedHashMap<>();
-        inputs.put("toto", String.class);
-        LinkedHashMap<String, Object> outputs = new LinkedHashMap<>();
-        outputs.put("tata", String.class);
-        LinkedHashMap<String, Object> data = new LinkedHashMap<>();
-        data.put("toto", "tata");
-        data.put("tata", "toto");
-        Process process = (Process) ProcessManager.createFactory().create().inputs(inputs).outputs(outputs).getProcess();
-        ProcessCheck processCheck = new ProcessCheck(process);
-        assertEquals(process.getIdentifier(), processCheck.getProcess().getIdentifier());
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.continueOnSuccess());
+        assertEquals(IProcessCheck.Action.CONTINUE, dummy.successAction);
+        assertNull(dummy.successMessage);
 
-        processCheck.onFail(IProcessCheck.STOP, "stop fail");
-        processCheck.onSuccess(IProcessCheck.CONTINUE, "continue success");
-        processCheck.setInOutputs(process.getProperty("toto"), process.getProperty("tata"));
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.continueOnSuccess(null));
+        assertEquals(IProcessCheck.Action.CONTINUE, dummy.successAction);
+        assertNull(dummy.successMessage);
 
-
-        processCheck.setClosure(null);
-        assertThrows(IllegalStateException.class, () -> processCheck.run(data));
-
-        processCheck.setClosure((Closure) new GroovyShell().evaluate("({a, b -> 'tata'})"));
-        assertThrows(IllegalStateException.class, () -> processCheck.run(data));
-
-        processCheck.setClosure((Closure) new GroovyShell().evaluate("({a, b -> false})"));
-        assertThrows(IllegalStateException.class, () -> processCheck.run(data));
+        dummy = new DummyProcessCheck(null);
+        builder = new CheckOptionBuilder(dummy);
+        assertNotNull(builder.continueOnSuccess());
+        assertEquals(IProcessCheck.Action.CONTINUE, dummy.successAction);
+        assertNull(dummy.successMessage);
     }
 }

--- a/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/DummyProcessCheck.java
+++ b/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/DummyProcessCheck.java
@@ -74,15 +74,10 @@ public class DummyProcessCheck implements IProcessCheck {
         this.inputOrOutput = inputOrOutput;
     }
 
-    @Override
-    public void setInOutPuts(@Nullable List<IInOutPut> inputOrOutput) {
-
-    }
-
     @NotNull
     @Override
-    public Optional<LinkedList<IInOutPut>> getInOutPuts() {
-        return Optional.empty();
+    public LinkedList<IInOutPut> getInOutPuts() {
+        return new LinkedList<>();
     }
 
     @Override

--- a/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/DummyProcessCheck.java
+++ b/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/DummyProcessCheck.java
@@ -1,0 +1,114 @@
+package org.orbisgis.orbisdata.processmanager.process.check;
+
+import groovy.lang.Closure;
+import org.orbisgis.commons.annotations.NotNull;
+import org.orbisgis.commons.annotations.Nullable;
+import org.orbisgis.orbisdata.processmanager.api.IProcess;
+import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck;
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@link IProcessCheck} implementation for test purpose.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2020)
+ */
+public class DummyProcessCheck implements IProcessCheck {
+
+    @Nullable
+    public LinkedHashMap<String, Object> processInData;
+    @Nullable
+    public Action failAction;
+    @Nullable
+    public String failMessage;
+    @Nullable
+    public Action successAction;
+    @Nullable
+    public String successMessage;
+    @Nullable
+    public IInOutPut[] inputOrOutput;
+    @Nullable
+    public Closure<?> closure;
+    @Nullable
+    public IProcess process;
+
+    public DummyProcessCheck(@Nullable IProcess process) {
+        this.process = process;
+    }
+
+    @Override
+    public boolean run(@Nullable LinkedHashMap<String, Object> processInData) {
+        this.processInData = processInData;
+        return false;
+    }
+
+    @Override
+    public void onFail(@Nullable Action action, @Nullable String message) {
+        this.failAction = action;
+        this.failMessage = message;
+    }
+
+    @Override
+    public void onFail(@Nullable String message) {
+        this.failMessage = message;
+    }
+
+    @Override
+    public void onSuccess(@Nullable Action action, @Nullable String message) {
+        this.successAction = action;
+        this.successMessage = message;
+    }
+
+    @Override
+    public void onSuccess(@Nullable String message) {
+        this.successMessage = message;
+    }
+
+    @Override
+    public void setInOutPuts(@Nullable IInOutPut... inputOrOutput) {
+        this.inputOrOutput = inputOrOutput;
+    }
+
+    @Override
+    public void setInOutPuts(@Nullable List<IInOutPut> inputOrOutput) {
+
+    }
+
+    @NotNull
+    @Override
+    public Optional<LinkedList<IInOutPut>> getInOutPuts() {
+        return Optional.empty();
+    }
+
+    @Override
+    public void setClosure(@Nullable Closure<?> cl) {
+        this.closure = cl;
+    }
+
+    @Override
+    @NotNull
+    public Optional<Closure<?>> getClosure() {
+        return Optional.ofNullable(closure);
+    }
+
+    @Override
+    public boolean fail() {
+        return false;
+    }
+
+    @Override
+    public boolean success() {
+        return false;
+    }
+
+    @NotNull
+    @Override
+    public Optional<IProcess> getProcess() {
+        return Optional.ofNullable(process);
+    }
+}

--- a/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/DummyProcessCheck.java
+++ b/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/DummyProcessCheck.java
@@ -9,7 +9,6 @@ import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Optional;
 
 /**

--- a/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/ProcessCheckTest.java
+++ b/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/ProcessCheckTest.java
@@ -50,7 +50,6 @@ import org.orbisgis.orbisdata.processmanager.process.ProcessManager;
 import org.orbisgis.orbisdata.processmanager.process.inoutput.Input;
 import org.orbisgis.orbisdata.processmanager.process.inoutput.Output;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Optional;
@@ -179,8 +178,7 @@ public class ProcessCheckTest {
         processCheck.setClosure(null);
         assertFalse(processCheck.getClosure().isPresent());
         processCheck.setInOutPuts((IInOutPut[]) null);
-        assertTrue(processCheck.getInOutPuts().isPresent());
-        assertTrue(processCheck.getInOutPuts().get().isEmpty());
+        assertTrue(processCheck.getInOutPuts().isEmpty());
         assertFalse(processCheck.run(null));
         assertFalse(processCheck.run(new LinkedHashMap<>()));
         assertFalse(processCheck.run(map));
@@ -213,8 +211,7 @@ public class ProcessCheckTest {
         assertTrue(processCheck.getClosure().isPresent());
         assertEquals(cl, processCheck.getClosure().get());
         processCheck.setInOutPuts(inOutPuts);
-        assertTrue(processCheck.getInOutPuts().isPresent());
-        assertEquals(3, processCheck.getInOutPuts().get().size());
+        assertEquals(3, processCheck.getInOutPuts().size());
         assertTrue(processCheck.run(null));
         assertTrue(processCheck.run(new LinkedHashMap<>()));
         assertTrue(processCheck.run(map));
@@ -385,5 +382,146 @@ public class ProcessCheckTest {
         assertNull(processCheck.invokeMethod("getClosure", null));
         assertNull(processCheck.invokeMethod("setClosure", cl));
         assertNull(processCheck.invokeMethod("getClosure", null));
+    }
+
+    /**
+     * Test the {@link ProcessCheck#toString()} method.
+     */
+    @Test
+    public void toStringTest() {
+        String str = "{in1, in2, in3 -> return in1+in2+in3 == 'abc'}";
+        Closure<?> cl = (Closure<?>) new GroovyShell().evaluate(new GroovyCodeSource(str, "script", ""));
+
+        IInOutPut[] inOutPuts = new IInOutPut[]{
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(PROCESS, "in2"),
+                new Input(PROCESS, "in3").optional("c"),
+                new Output(PROCESS, "out1")};
+
+        ProcessCheck processCheck = new ProcessCheck(null);
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts((IInOutPut[]) null);
+        assertEquals("No check can be run as there is no closure nor in/outputs set.", processCheck.toString());
+
+        processCheck = new ProcessCheck(null);
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts(inOutPuts);
+        assertEquals("ProcessCheck : \n" +
+                "Check that inputs :\n" +
+                "\tin1\n" +
+                "\tin2\n" +
+                "\tin3\n" +
+                "are equals to provided data.", processCheck.toString());
+
+        processCheck = new ProcessCheck(null);
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts((IInOutPut[]) null);
+        assertEquals("ProcessCheck : \n" +
+                "Verifies a closure"
+                , processCheck.toString());
+
+        processCheck = new ProcessCheck(null);
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts(inOutPuts);
+        assertEquals("ProcessCheck : \n" +
+                "Check that inputs :\n" +
+                "\tin1\n" +
+                "\tin2\n" +
+                "\tin3\n" +
+                "Verifies a closure", processCheck.toString());
+
+        processCheck = new ProcessCheck(PROCESS);
+        assertTrue(processCheck.getProcess().isPresent());
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts((IInOutPut[]) null);
+        assertEquals("No check can be run as there is no closure nor in/outputs set.", processCheck.toString());
+
+        processCheck = new ProcessCheck(PROCESS);
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts(inOutPuts);
+        assertEquals("ProcessCheck : \n" +
+                "On process :" + processCheck.getProcess().get().getIdentifier() + "\n" +
+                "Check that inputs :\n" +
+                "\tin1\n" +
+                "\tin2\n" +
+                "\tin3\n" +
+                "and output :\n" +
+                "\tout1\n" +
+                "are equals to provided data.", processCheck.toString());
+
+        processCheck = new ProcessCheck(PROCESS);
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts((IInOutPut[]) null);
+        assertEquals("ProcessCheck : \n" +
+                "On process :" + processCheck.getProcess().get().getIdentifier() + "\n" +
+                "Verifies a closure", processCheck.toString());
+
+        processCheck = new ProcessCheck(PROCESS);
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts(inOutPuts);
+        assertEquals("ProcessCheck : \n" +
+                "On process :" + processCheck.getProcess().get().getIdentifier() + "\n" +
+                "Check that inputs :\n" +
+                "\tin1\n" +
+                "\tin2\n" +
+                "\tin3\n" +
+                "and output :\n" +
+                "\tout1\n" +
+                "Verifies a closure", processCheck.toString());
+
+
+        LinkedHashMap<String, Object> outputs = new LinkedHashMap<>();
+        outputs.put("out1", new Output());
+
+        LinkedHashMap<String, Object> inputs = new LinkedHashMap<>();
+        inputs.put("in1", new Input());
+        inputs.put("in2", new Input());
+        inputs.put("in3", new Input());
+        IProcess namedProcess = ProcessManager.createFactory()
+                .create()
+                .title("namedProcess")
+                .outputs(outputs)
+                .inputs(inputs)
+                .run(cl)
+                .getProcess();
+
+        processCheck = new ProcessCheck(namedProcess);
+        assertTrue(processCheck.getProcess().isPresent());
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts((IInOutPut[]) null);
+        assertEquals("No check can be run as there is no closure nor in/outputs set.", processCheck.toString());
+
+        processCheck = new ProcessCheck(namedProcess);
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts(inOutPuts);
+        assertEquals("ProcessCheck : \n" +
+                "On process :namedProcess\n" +
+                "Check that inputs :\n" +
+                "\tin1\n" +
+                "\tin2\n" +
+                "\tin3\n" +
+                "and output :\n" +
+                "\tout1\n" +
+                "are equals to provided data.", processCheck.toString());
+
+        processCheck = new ProcessCheck(namedProcess);
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts((IInOutPut[]) null);
+        assertEquals("ProcessCheck : \n" +
+                "On process :namedProcess\n" +
+                "Verifies a closure", processCheck.toString());
+
+        processCheck = new ProcessCheck(namedProcess);
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts(inOutPuts);
+        assertEquals("ProcessCheck : \n" +
+                "On process :namedProcess\n" +
+                "Check that inputs :\n" +
+                "\tin1\n" +
+                "\tin2\n" +
+                "\tin3\n" +
+                "and output :\n" +
+                "\tout1\n" +
+                "Verifies a closure", processCheck.toString());
     }
 }

--- a/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/ProcessCheckTest.java
+++ b/process-manager/process/src/test/java/org/orbisgis/orbisdata/processmanager/process/check/ProcessCheckTest.java
@@ -1,0 +1,389 @@
+/*
+ * Bundle ProcessManager is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * ProcessManager is distributed under LGPL 3 license.
+ *
+ * Copyright (C) 2018 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * ProcessManager is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * ProcessManager is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * ProcessManager. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.orbisdata.processmanager.process.check;
+
+import groovy.lang.Closure;
+import groovy.lang.GroovyCodeSource;
+import groovy.lang.GroovyShell;
+import org.codehaus.groovy.runtime.InvokerHelper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.orbisgis.commons.annotations.Nullable;
+import org.orbisgis.orbisdata.processmanager.api.IProcess;
+import org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck;
+import org.orbisgis.orbisdata.processmanager.api.inoutput.IInOutPut;
+import org.orbisgis.orbisdata.processmanager.process.ProcessManager;
+import org.orbisgis.orbisdata.processmanager.process.inoutput.Input;
+import org.orbisgis.orbisdata.processmanager.process.inoutput.Output;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.CONTINUE;
+import static org.orbisgis.orbisdata.processmanager.api.check.IProcessCheck.Action.STOP;
+
+/**
+ * Test class dedicated to {@link ProcessCheck} class.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS 2020)
+ */
+public class ProcessCheckTest {
+
+    private static IProcess PROCESS;
+
+    @Nullable
+    private static IProcess NULL_PROCESS;
+
+    @BeforeAll
+    public static void beforeAll() {
+        LinkedHashMap<String, Object> outputs = new LinkedHashMap<>();
+        outputs.put("out1", new Output());
+
+        LinkedHashMap<String, Object> inputs = new LinkedHashMap<>();
+        inputs.put("in1", new Input());
+        inputs.put("in2", new Input());
+        inputs.put("in3", new Input());
+
+        String str = "{in1, in2, in3 -> return [out1:in1+in2+in3]}";
+        Closure<?> cl = (Closure<?>) new GroovyShell().evaluate(new GroovyCodeSource(str, "script", ""));
+
+        PROCESS = ProcessManager.createFactory()
+                .create()
+                .outputs(outputs)
+                .inputs(inputs)
+                .run(cl)
+                .getProcess();
+        NULL_PROCESS = null;
+    }
+
+    /**
+     * Test the {@link ProcessCheck#getProcess()} method.
+     */
+    @Test
+    public void getProcessTest() {
+        assertTrue(new ProcessCheck(PROCESS).getProcess().isPresent());
+        assertFalse(new ProcessCheck(NULL_PROCESS).getProcess().isPresent());
+    }
+
+    /**
+     * Test the {@link ProcessCheck#fail()}, {@link ProcessCheck#success()},
+     * {@link ProcessCheck#onFail(String)}, {@link ProcessCheck#onFail(IProcessCheck.Action, String)},
+     * {@link ProcessCheck#onSuccess(String)}, {@link ProcessCheck#onSuccess(IProcessCheck.Action, String)} methods.
+     */
+    @Test
+    public void failSuccessTest() {
+        String message = "message";
+        ProcessCheck check = new ProcessCheck(PROCESS);
+
+        assertTrue(check::fail);
+        assertFalse(check::success);
+
+        check.onFail(null, message);
+        assertTrue(check::fail);
+        check.onFail(null, null);
+        assertTrue(check::fail);
+        check.onFail(STOP, message);
+        assertTrue(check::fail);
+        check.onFail(STOP, null);
+        assertTrue(check::fail);
+        check.onFail(CONTINUE, message);
+        assertFalse(check::fail);
+        check.onFail(CONTINUE, null);
+        assertFalse(check::fail);
+        check.onFail(message);
+        assertTrue(check::fail);
+        check.onFail(null);
+        assertTrue(check::fail);
+
+        check.onSuccess(null, message);
+        assertTrue(check::success);
+        check.onSuccess(null, null);
+        assertTrue(check::success);
+        check.onSuccess(STOP, message);
+        assertTrue(check::success);
+        check.onSuccess(STOP, null);
+        assertTrue(check::success);
+        check.onSuccess(CONTINUE, message);
+        assertFalse(check::success);
+        check.onSuccess(CONTINUE, null);
+        assertFalse(check::success);
+        check.onSuccess(message);
+        assertFalse(check::success);
+        check.onSuccess(null);
+        assertFalse(check::success);
+    }
+
+    /**
+     * Test the {@link ProcessCheck#run(LinkedHashMap)}, {@link ProcessCheck#setClosure(Closure)},
+     * {@link ProcessCheck#setInOutPuts(IInOutPut...)} methods.
+     */
+    @Test
+    public void runTest() {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("in1", "a");
+        map.put("in2", "b");
+
+        String str = "{in1, in2, in3 -> return in1+in2+in3 == 'abc'}";
+        Closure<?> cl = (Closure<?>) new GroovyShell().evaluate(new GroovyCodeSource(str, "script", ""));
+
+        IInOutPut[] emptyInOutPuts = new IInOutPut[]{};
+        IInOutPut[] inOutPuts = new IInOutPut[]{
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(PROCESS, "in2"),
+                new Input(PROCESS, "in3").optional("c")};
+
+        ProcessCheck processCheck = new ProcessCheck(PROCESS);
+
+        //Ensure the check is not run
+        processCheck.onFail(STOP, null);
+        processCheck.onSuccess(STOP, null);
+
+        processCheck.setClosure(null);
+        assertFalse(processCheck.getClosure().isPresent());
+        processCheck.setInOutPuts((IInOutPut[]) null);
+        assertTrue(processCheck.getInOutPuts().isPresent());
+        assertTrue(processCheck.getInOutPuts().get().isEmpty());
+        assertFalse(processCheck.run(null));
+        assertFalse(processCheck.run(new LinkedHashMap<>()));
+        assertFalse(processCheck.run(map));
+
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts(emptyInOutPuts);
+        assertFalse(processCheck.run(null));
+        assertFalse(processCheck.run(new LinkedHashMap<>()));
+        assertFalse(processCheck.run(map));
+
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts(inOutPuts);
+        assertFalse(processCheck.run(null));
+        assertFalse(processCheck.run(new LinkedHashMap<>()));
+        assertTrue(processCheck.run(map));
+
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts((IInOutPut[]) null);
+        assertTrue(processCheck.run(null));
+        assertTrue(processCheck.run(new LinkedHashMap<>()));
+        assertTrue(processCheck.run(map));
+
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts(emptyInOutPuts);
+        assertTrue(processCheck.run(null));
+        assertTrue(processCheck.run(new LinkedHashMap<>()));
+        assertTrue(processCheck.run(map));
+
+        processCheck.setClosure(cl);
+        assertTrue(processCheck.getClosure().isPresent());
+        assertEquals(cl, processCheck.getClosure().get());
+        processCheck.setInOutPuts(inOutPuts);
+        assertTrue(processCheck.getInOutPuts().isPresent());
+        assertEquals(3, processCheck.getInOutPuts().get().size());
+        assertTrue(processCheck.run(null));
+        assertTrue(processCheck.run(new LinkedHashMap<>()));
+        assertTrue(processCheck.run(map));
+
+
+        //Test that check without closure fail when required
+        IInOutPut[] inOutPutsOpt = new IInOutPut[]{
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(PROCESS, "in2").optional("b"),
+                new Input(PROCESS, "in3").optional("c"),
+                new Output(PROCESS, "out1")};
+        IInOutPut[] noNameInOutPuts = new IInOutPut[]{
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(PROCESS, null).optional("b"),
+                new Input(PROCESS, null).optional("c"),
+                new Output(PROCESS, "out1")};
+
+        LinkedHashMap<String, Object> mapMissingInputs = new LinkedHashMap<>();
+        mapMissingInputs.put("in1", "a");
+
+        LinkedHashMap<String, Object> mapInvalidInputs = new LinkedHashMap<>();
+        mapInvalidInputs.put("in1", "a");
+        mapInvalidInputs.put("in2", "a");
+        mapInvalidInputs.put("in3", "a");
+
+        LinkedHashMap<String, Object> mapInputs = new LinkedHashMap<>();
+        mapInputs.put("in1", "a");
+        mapInputs.put("in2", "b");
+        mapInputs.put("in3", "c");
+
+        processCheck.onFail(STOP, null);
+        processCheck.onSuccess(CONTINUE, null);
+
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts(noNameInOutPuts);
+        assertTrue(processCheck.run(map));
+
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts(inOutPuts);
+        assertTrue(processCheck.run(mapInputs));
+
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts(inOutPutsOpt);
+        assertTrue(processCheck.run(mapMissingInputs));
+
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts(inOutPutsOpt);
+        assertTrue(processCheck.run(mapInvalidInputs));
+
+
+        //Test that check with closure fail when required
+        IInOutPut[] inOutPutsNullProcess = new IInOutPut[]{
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(null, "in2").optional("b"),
+                new Input(PROCESS, "in3").optional("c"),
+                new Output(PROCESS, "out1")};
+
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts(inOutPutsNullProcess);
+        assertTrue(processCheck.run(mapInputs));
+
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts(noNameInOutPuts);
+        assertTrue(processCheck.run(mapInputs));
+
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts(noNameInOutPuts);
+        assertTrue(processCheck.run(null));
+
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts(inOutPuts);
+        assertTrue(processCheck.run(mapInvalidInputs));
+
+        String str2 = "{in1, in2, in3 -> return in1+in2+in3}";
+        Closure<?> badCl = (Closure<?>) new GroovyShell().evaluate(new GroovyCodeSource(str2, "script", ""));
+
+        processCheck.setClosure(badCl);
+        processCheck.setInOutPuts(inOutPuts);
+        assertTrue(processCheck.run(mapInputs));
+
+        String str3 = "{in1, in2, in3 -> return false}";
+        Closure<?> falseCl = (Closure<?>) new GroovyShell().evaluate(new GroovyCodeSource(str3, "script", ""));
+
+        processCheck.setClosure(falseCl);
+        processCheck.setInOutPuts(inOutPuts);
+        assertTrue(processCheck.run(mapInputs));
+
+        processCheck.setClosure(null);
+        processCheck.setInOutPuts(
+                new Input(PROCESS, "in1").optional("a"),
+                new Input(PROCESS, "in2").optional("b"),
+                new Input(PROCESS, "in3").optional("c"));
+        assertFalse(processCheck.run(mapInputs));
+
+        processCheck.setClosure(cl);
+        processCheck.setInOutPuts(
+                new Input(PROCESS, "in1"),
+                new Input(PROCESS, "in2"),
+                new Input(PROCESS, "in3"));
+        assertFalse(processCheck.run(mapInputs));
+
+        String str4 = "{out1 -> return out1== 'abc'}";
+        Closure<?> outCl = (Closure<?>) new GroovyShell().evaluate(new GroovyCodeSource(str4, "script", ""));
+
+        assertTrue(PROCESS.execute(mapInputs));
+        processCheck.setClosure(outCl);
+        processCheck.setInOutPuts(new Output(PROCESS, "out1"));
+        assertFalse(processCheck.run(mapInputs));
+    }
+
+    /**
+     * Test the {@link ProcessCheck#setProperty(String, Object)}, {@link ProcessCheck#getProperty(String)} methods.
+     */
+    @Test
+    public void propertyTest() {
+        ProcessCheck processCheck = new ProcessCheck(PROCESS);
+
+        assertDoesNotThrow(() -> processCheck.setProperty(null, "value"));
+
+        processCheck.setProperty("inOutPuts", null);
+        Object obj = processCheck.getProperty("inOutPuts");
+        assertFalse(obj instanceof Optional);
+        assertTrue(obj instanceof LinkedList);
+        assertTrue(((LinkedList<?>) obj).isEmpty());
+
+        processCheck.setProperty("inOutPuts", new IInOutPut[]{new Input()});
+        obj = processCheck.getProperty("inOutPuts");
+        assertFalse(obj instanceof Optional);
+        assertTrue(obj instanceof LinkedList);
+        assertEquals(1, ((LinkedList<?>)obj).size());
+
+        processCheck.setMetaClass(null);
+        processCheck.setProperty("inOutPuts", null);
+        obj = processCheck.getProperty("inOutPuts");
+        assertNull(obj);
+
+        processCheck.setMetaClass(InvokerHelper.getMetaClass(processCheck.getClass()));
+        obj = processCheck.getProperty("inOutPuts");
+        assertNotNull(obj);
+
+        processCheck.setProperty("metaClass", InvokerHelper.getMetaClass(getClass()));
+        obj = processCheck.getProperty("metaClass");
+        assertNotNull(obj);
+    }
+
+    /**
+     * Test the {@link ProcessCheck#invokeMethod(String, Object)} methods.
+     */
+    @Test
+    public void invokeMethodTest() {
+        ProcessCheck processCheck = new ProcessCheck(PROCESS);
+
+        assertNull(processCheck.invokeMethod(null, "value"));
+        assertNull(processCheck.invokeMethod(null, null));
+        assertNull(processCheck.invokeMethod("setClosure", null));
+        assertNull(processCheck.invokeMethod("getClosure", null));
+
+        String str = "{in1, in2, in3 -> return in1+in2+in3 == 'abc'}";
+        Closure<?> cl = (Closure<?>) new GroovyShell().evaluate(new GroovyCodeSource(str, "script", ""));
+
+        assertNull(processCheck.invokeMethod("setClosure", cl));
+        assertNotNull(processCheck.invokeMethod("getClosure", null));
+
+        processCheck.setMetaClass(null);
+        assertNull(processCheck.invokeMethod(null, "value"));
+        assertNull(processCheck.invokeMethod(null, null));
+        assertNull(processCheck.invokeMethod("setClosure", null));
+        assertNull(processCheck.invokeMethod("getClosure", null));
+        assertNull(processCheck.invokeMethod("setClosure", cl));
+        assertNull(processCheck.invokeMethod("getClosure", null));
+    }
+}


### PR DESCRIPTION
On `process.check` package :
Avoid returning null values (use `Optional` when needed). No changes for Groovy usage, as Optional are converted to Object or `null`
Make all methods parameters nullable.
Cover with tests.

linked to #198, #199, #200 