### PR TITLE
Fix on getSpatialTable

### DIFF
--- a/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyH2GISTest.groovy
+++ b/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyH2GISTest.groovy
@@ -748,7 +748,7 @@ class GroovyH2GISTest {
                 DROP TABLE IF EXISTS H2GIS;
                 CREATE TABLE H2GIS (id int, the_geom geometry(point, 4326));
         """)
-        assertEquals(4326, h2GIS.getSpatialTable("postgis").srid)
+        assertEquals(4326, h2GIS.getSpatialTable("H2GIS").srid)
 
         h2GIS.execute("""
                 DROP SCHEMA IF EXISTS cnrs CASCADE;

--- a/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyH2GISTest.groovy
+++ b/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyH2GISTest.groovy
@@ -37,6 +37,7 @@
 package org.orbisgis.orbisdata.datamanager.jdbc
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Point
@@ -738,5 +739,22 @@ class GroovyH2GISTest {
         assertEquals 4326, geom.SRID
         assertEquals("POLYGON ((28 0, 28 42, 84 42, 84 0, 28 0))", geom.toString());
         h2GIS.execute("drop table forests");
+    }
+
+    @Test
+    void sridOnEmptyTable() {
+        def h2GIS = H2GIS.open('./target/orbisgis')
+        h2GIS.execute("""
+                DROP TABLE IF EXISTS H2GIS;
+                CREATE TABLE H2GIS (id int, the_geom geometry(point, 4326));
+        """)
+        assertEquals(4326, h2GIS.getSpatialTable("postgis").srid)
+
+        h2GIS.execute("""
+                DROP SCHEMA IF EXISTS cnrs CASCADE;
+                CREATE SCHEMA cnrs ;
+                CREATE TABLE cnrs.H2GIS (id int, the_geom geometry(point, 4326));
+        """)
+        assertEquals(4326, h2GIS.getSpatialTable("CNRS.H2GIS").srid)
     }
 }

--- a/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyPostGISTest.groovy
+++ b/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyPostGISTest.groovy
@@ -330,4 +330,21 @@ class GroovyPostGISTest {
         assertTrue geom instanceof Polygon
         assertEquals("POLYGON ((28 0, 28 42, 84 42, 84 0, 28 0))", geom.toString());
     }
+
+    @Test
+    @EnabledIfSystemProperty(named = "test.postgis", matches = "true")
+    void sridOnEmptyTable() {
+        postGIS.execute("""
+                DROP TABLE IF EXISTS postgis;
+                CREATE TABLE postgis (id int, the_geom geometry(point, 4326));
+        """)
+        assertEquals(4326, postGIS.getSpatialTable("postgis").srid)
+
+        postGIS.execute("""
+                DROP SCHEMA IF EXISTS cnrs CASCADE;
+                CREATE SCHEMA cnrs ;
+                CREATE TABLE cnrs.postgis (id int, the_geom geometry(point, 4326));
+        """)
+        assertEquals(4326, postGIS.getSpatialTable("cnrs.postgis").srid)
+    }
 }

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSourceTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSourceTest.java
@@ -775,12 +775,14 @@ class JdbcDataSourceTest {
     void testGetTableNames() {
         Collection<String> names = ds1.getTableNames();
         assertNotNull(names);
+        assertTrue(names.size()>0);
         assertTrue(names.contains("JDBCDATASOURCETEST.PUBLIC.GEOMETRY_COLUMNS"));
         assertTrue(names.contains("JDBCDATASOURCETEST.PUBLIC.TEST"));
         assertTrue(names.contains("JDBCDATASOURCETEST.PUBLIC.SPATIAL_REF_SYS"));
 
         names = ds2.getTableNames();
         assertNotNull(names);
+        assertTrue(names.size()>0);
         assertTrue(names.contains("\"db_postgresql_mode\".\"public\".\"geometry_columns\""));//Due to the H2 driver
         assertTrue(names.contains("\"db_postgresql_mode\".\"public\".\"test\""));
         assertTrue(names.contains("\"db_postgresql_mode\".\"public\".\"spatial_ref_sys\""));
@@ -831,6 +833,7 @@ class JdbcDataSourceTest {
     void testHasTable() {
         Collection<String> names = ds1.getTableNames();
         assertNotNull(names);
+        assertTrue(names.size()>0);
         assertTrue(ds1.hasTable("GEOMETRY_COLUMNS"));
         assertTrue(ds1.hasTable("TEST"));
         assertTrue(ds1.hasTable("JDBCDATASOURCETEST.PUBLIC.SPATIAL_REF_SYS"));

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSourceTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSourceTest.java
@@ -112,10 +112,7 @@ class JdbcDataSourceTest {
         st.execute("INSERT INTO test VALUES (1, 'POINT(0 0)', 'toto')");
         st.execute("INSERT INTO test VALUES (2, 'LINESTRING(0 0, 1 1, 2 2)', 'tata')");
         st.execute("INSERT INTO test VALUES (3, 'POINT(4 5)', 'titi')");
-
         ds1 = new DummyJdbcDataSource(dataSource, DataBaseType.H2GIS);
-
-
         DataSource ds_postgres = H2GISDBFactory.createDataSource(new File(DB_POSTGRES_MODE).toURI().toString(), true);
         Connection con_postgres = ds_postgres.getConnection();
         Statement st_postgres = con_postgres.createStatement();
@@ -124,10 +121,7 @@ class JdbcDataSourceTest {
         st_postgres.execute("INSERT INTO test VALUES (1, 'POINT(0 0)', 'toto')");
         st_postgres.execute("INSERT INTO test VALUES (2, 'LINESTRING(0 0, 1 1, 2 2)', 'tata')");
         st_postgres.execute("INSERT INTO test VALUES (3, 'POINT(4 5)', 'titi')");
-
         ds2 = new DummyJdbcDataSource(con_postgres, DataBaseType.POSTGIS);
-
-
     }
 
     /**
@@ -146,7 +140,6 @@ class JdbcDataSourceTest {
         assertEquals(ds1.getDataSource().unwrap(DataSource.class), ds1.unwrap(DataSource.class));
         assertEquals(ds1.getDataSource().isWrapperFor(DataSource.class), ds1.isWrapperFor(DataSource.class));
         assertEquals(ds1.getDataSource().getParentLogger(), ds1.getParentLogger());
-
         assertNull(ds2.getDataSource());
         assertNull(ds2.getConnection("sa", "sa"));
         assertNull(ds2.getLogWriter());

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSourceTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSourceTest.java
@@ -407,44 +407,28 @@ class JdbcDataSourceTest {
         ds2.execute("DROP TABLE IF EXISTS load");
 
         assertTrue(ds1.save("test", "target/save_path_ds1.geojson"));
-        assertTrue(ds2.save("test", "target/save_path_ds2.geojson"));
         assertTrue(new File("target/save_path_ds1.geojson").exists());
-        assertTrue(new File("target/save_path_ds2.geojson").exists());
 
         assertTrue(ds1.save("test", "target/save_path_enc_ds1.geojson", "UTF8"));
-        assertTrue(ds2.save("test", "target/save_path_enc_ds2.geojson", "UTF8"));
         assertTrue(new File("target/save_path_enc_ds1.geojson").exists());
-        assertTrue(new File("target/save_path_enc_ds2.geojson").exists());
 
         assertTrue(ds1.save("test", new File("target/save_url_ds1.geojson").toURI().toURL()));
-        assertTrue(ds2.save("test", new File("target/save_url_ds2.geojson").toURI().toURL()));
         assertTrue(new File("target/save_url_ds1.geojson").exists());
-        assertTrue(new File("target/save_url_ds2.geojson").exists());
 
         assertTrue(ds1.save("test", new File("target/save_url_enc_ds1.geojson").toURI().toURL(), "UTF8"));
-        assertTrue(ds2.save("test", new File("target/save_url_enc_ds2.geojson").toURI().toURL(), "UTF8"));
         assertTrue(new File("target/save_url_enc_ds1.geojson").exists());
-        assertTrue(new File("target/save_url_enc_ds2.geojson").exists());
 
         assertTrue(ds1.save("test", new File("target/save_uri_ds1.geojson").toURI()));
-        assertTrue(ds2.save("test", new File("target/save_uri_ds2.geojson").toURI()));
         assertTrue(new File("target/save_uri_ds1.geojson").exists());
-        assertTrue(new File("target/save_uri_ds2.geojson").exists());
 
         assertTrue(ds1.save("test", new File("target/save_uri_enc_ds1.geojson").toURI(), "UTF8"));
-        assertTrue(ds2.save("test", new File("target/save_uri_enc_ds2.geojson").toURI(), "UTF8"));
         assertTrue(new File("target/save_uri_enc_ds1.geojson").exists());
-        assertTrue(new File("target/save_uri_enc_ds2.geojson").exists());
 
         assertTrue(ds1.save("test", new File("target/save_file_ds1.geojson")));
-        assertTrue(ds2.save("test", new File("target/save_file_ds2.geojson")));
         assertTrue(new File("target/save_file_ds1.geojson").exists());
-        assertTrue(new File("target/save_file_ds2.geojson").exists());
 
         assertTrue(ds1.save("test", new File("target/save_file_enc_ds1.geojson"), "UTF8"));
-        assertTrue(ds2.save("test", new File("target/save_file_enc_ds2.geojson"), "UTF8"));
         assertTrue(new File("target/save_file_enc_ds1.geojson").exists());
-        assertTrue(new File("target/save_file_enc_ds2.geojson").exists());
     }
 
     /**
@@ -833,12 +817,18 @@ class JdbcDataSourceTest {
         assertTrue(names.contains("THE_GEOM"));
         assertTrue(names.contains("TEXT"));
 
-        names = ds2.getColumnNames("jdbcdatasourcetest.public.test");
-        assertNull(names);
+        names = ds2.getColumnNames("db_postgresql_mode.public.test");
+        assertTrue(names.contains("id"));
+        assertTrue(names.contains("the_geom"));
+        assertTrue(names.contains("text"));
         names = ds2.getColumnNames("public.test");
-        assertNull(names);
+        assertTrue(names.contains("id"));
+        assertTrue(names.contains("the_geom"));
+        assertTrue(names.contains("text"));
         names = ds2.getColumnNames("test");
-        assertNull(names);
+        assertTrue(names.contains("id"));
+        assertTrue(names.contains("the_geom"));
+        assertTrue(names.contains("text"));
     }
 
     /**

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
@@ -568,6 +568,7 @@ class JdbcTableTest {
     @Test
     void testGetRowCount() {
         assertEquals(2, getTable().getRowCount());
+        assertEquals(2, getLinkedTable().getRowCount());
         assertEquals(1, getTempTable().getRowCount());
         assertEquals(0, getEmptyTable().getRowCount());
         assertEquals(2, getBuiltTable().getRowCount());

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
@@ -170,6 +170,8 @@ class JdbcTableTest {
                     "','sa','sa','" + TABLE_NAME + "')");
             statement.execute("CREATE TEMPORARY TABLE " + TEMP_NAME + " (" + COL_THE_GEOM + " GEOMETRY, " + COL_THE_GEOM2 + " GEOMETRY(POINT Z)," +
                     COL_ID + " INTEGER, " + COL_VALUE + " FLOAT, " + COL_MEANING + " VARCHAR)");
+            statement.execute("INSERT INTO " + TEMP_NAME + " VALUES ('POINT(0 1 2)', 'POINT(10 11 12)', 2, 0.568, '3D point')");
+
             statement.execute("CREATE TABLE " + EMPTY_NAME + " (" + COL_THE_GEOM + " GEOMETRY, " + COL_THE_GEOM2 + " GEOMETRY(POINT Z)," +
                     COL_ID + " INTEGER, " + COL_VALUE + " FLOAT, " + COL_MEANING + " VARCHAR)");
 

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
@@ -253,7 +253,7 @@ class JdbcTableTest {
         str = getTempTable().stream()
                 .map(resultSet -> resultSet.getObject(COL_THE_GEOM).toString())
                 .collect(Collectors.joining(" ; "));
-        assertEquals("", str);
+        assertEquals("POINT (0 1)", str);
 
         str = getBuiltTable().stream()
                 .map(resultSet -> resultSet.getObject(COL_THE_GEOM).toString())
@@ -313,7 +313,7 @@ class JdbcTableTest {
         assertEquals("Simple points", map.get(COL_MEANING));
 
         map = getTempTable().firstRow();
-        assertTrue(map.isEmpty());
+        assertTrue(!map.isEmpty());
 
         map = getEmptyTable().firstRow();
         assertTrue(map.isEmpty());
@@ -568,8 +568,7 @@ class JdbcTableTest {
     @Test
     void testGetRowCount() {
         assertEquals(2, getTable().getRowCount());
-        assertEquals(2, getLinkedTable().getRowCount());
-        assertEquals(0, getTempTable().getRowCount());
+        assertEquals(1, getTempTable().getRowCount());
         assertEquals(0, getEmptyTable().getRowCount());
         assertEquals(2, getBuiltTable().getRowCount());
     }
@@ -914,10 +913,10 @@ class JdbcTableTest {
         assertEquals(5, getEmptyTable().getSummary().getColumnCount());
         assertEquals(0, getEmptyTable().getSummary().getRowCount());
 
-        assertEquals("\"TEMPTABLE\"; row count : 0; column count : 5", getTempTable().getSummary().toString());
+        assertEquals("\"TEMPTABLE\"; row count : 1; column count : 5", getTempTable().getSummary().toString());
         assertEquals("\"TEMPTABLE\"", getTempTable().getSummary().getLocation().toString());
         assertEquals(5, getTempTable().getSummary().getColumnCount());
-        assertEquals(0, getTempTable().getSummary().getRowCount());
+        assertEquals(1, getTempTable().getSummary().getRowCount());
 
         assertEquals("\"LINKEDTABLE\"; row count : 2; column count : 5", getLinkedTable().getSummary().toString());
         assertEquals("\"LINKEDTABLE\"", getLinkedTable().getSummary().getLocation().toString());


### PR DESCRIPTION
Fix catalog.schema.table with getSpatialTable and getTable methods. These methods did not work with schema and  PostGIS datasource.
Fix getSRID on empty table. Must used the metadada of the table
Fix several on jdbc implementation to be sure that the correct database context is used. Upper case for H2GIS and lower case for PostGIS
Clean the code