### PR TITLE
Make filter more universal (do not use "WHERE")

### DIFF
--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dsl/IWhereBuilderOrOptionBuilder.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dsl/IWhereBuilderOrOptionBuilder.java
@@ -57,4 +57,6 @@ public interface IWhereBuilderOrOptionBuilder extends IOptionBuilder {
      * @return {@link IConditionOrOptionBuilder} instance to continue building.
      */
     IConditionOrOptionBuilder where(String condition);
+
+    IWhereBuilderOrOptionBuilder option(String option);
 }

--- a/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/IJdbcTableTest.java
+++ b/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/dataset/IJdbcTableTest.java
@@ -43,6 +43,7 @@ import org.orbisgis.commons.annotations.Nullable;
 import org.orbisgis.orbisdata.datamanager.api.datasource.IJdbcDataSource;
 import org.orbisgis.orbisdata.datamanager.api.dsl.IConditionOrOptionBuilder;
 import org.orbisgis.orbisdata.datamanager.api.dsl.IOptionBuilder;
+import org.orbisgis.orbisdata.datamanager.api.dsl.IWhereBuilderOrOptionBuilder;
 
 import javax.sql.rowset.RowSetMetaDataImpl;
 import java.io.InputStream;
@@ -1192,6 +1193,11 @@ public class IJdbcTableTest {
 
         @Override
         public IConditionOrOptionBuilder where(String condition) {
+            return null;
+        }
+
+        @Override
+        public IWhereBuilderOrOptionBuilder option(String option) {
             return null;
         }
 

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTable.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTable.java
@@ -57,6 +57,7 @@ import org.orbisgis.orbisdata.datamanager.api.dataset.ITable;
 import org.orbisgis.orbisdata.datamanager.api.datasource.IJdbcDataSource;
 import org.orbisgis.orbisdata.datamanager.api.dsl.IConditionOrOptionBuilder;
 import org.orbisgis.orbisdata.datamanager.api.dsl.IOptionBuilder;
+import org.orbisgis.orbisdata.datamanager.api.dsl.IWhereBuilderOrOptionBuilder;
 import org.orbisgis.orbisdata.datamanager.jdbc.dsl.OptionBuilder;
 import org.orbisgis.orbisdata.datamanager.jdbc.dsl.WhereBuilder;
 import org.orbisgis.orbisdata.datamanager.jdbc.io.IOMethods;
@@ -714,6 +715,11 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable<S
     }
 
     @Override
+    public IWhereBuilderOrOptionBuilder option(String option) {
+        return new WhereBuilder(getQuery(), getJdbcDataSource()).option(option);
+    }
+
+    @Override
     public IOptionBuilder groupBy(String... fields) {
         return new OptionBuilder(getQuery(), getJdbcDataSource()).groupBy(fields);
     }
@@ -741,7 +747,7 @@ public abstract class JdbcTable extends DefaultResultSet implements IJdbcTable<S
     @Override
     @Nullable
     public JdbcTable filter(String filter) {
-        return (JdbcTable)where(filter).getTable();
+        return (JdbcTable)option(filter).getTable();
     }
 
     @Override

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/dsl/WhereBuilder.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/dsl/WhereBuilder.java
@@ -72,4 +72,10 @@ public class WhereBuilder extends OptionBuilder implements IWhereBuilderOrOption
         query.append(condition);
         return new ConditionOrOptionBuilder(query.toString(), dataSource);
     }
+
+    @Override
+    public IWhereBuilderOrOptionBuilder option(String option) {
+        query.append(option);
+        return new WhereBuilder(query.toString(), dataSource);
+    }
 }

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
@@ -925,6 +925,13 @@ class JdbcTableTest {
         assertEquals(2, getLinkedTable().getSummary().getRowCount());
     }
 
+    @Test
+    public void filterTest(){
+        assertArrayEquals(new int[]{5, 1}, getTable().filter("limit 1").getTable().getSize());
+        assertArrayEquals(new int[]{5, 0}, getTable().filter("where ID=34").getTable().getSize());
+        assertArrayEquals(new int[]{5, 1}, getTable().filter("where ID=1").getTable().getSize());
+    }
+
     /**
      * Simple implementation of the {@link JdbcDataSource} abstract class for test purpose.
      */

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTableTest.java
@@ -928,6 +928,7 @@ class JdbcTableTest {
     @Test
     public void filterTest(){
         assertArrayEquals(new int[]{5, 1}, getTable().filter("limit 1").getTable().getSize());
+        assertArrayEquals(new int[]{5, 0}, getTable().filter("where ID=34").filter("limit 1").getTable().getSize());
         assertArrayEquals(new int[]{5, 0}, getTable().filter("where ID=34").getTable().getSize());
         assertArrayEquals(new int[]{5, 1}, getTable().filter("where ID=1").getTable().getSize());
     }


### PR DESCRIPTION
Make filter more universal (do not use "WHERE") like : 
``` groovy
table.filter("where ID=34").filter("limit 1").table()
```