### PR TITLE
Fix prepared statement

### DIFF
--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/datasource/IJdbcDataSource.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/datasource/IJdbcDataSource.java
@@ -45,6 +45,7 @@ import org.orbisgis.orbisdata.datamanager.api.dataset.DataBaseType;
 import org.orbisgis.orbisdata.datamanager.api.dataset.IJdbcSpatialTable;
 import org.orbisgis.orbisdata.datamanager.api.dataset.IJdbcTable;
 import org.orbisgis.orbisdata.datamanager.api.dataset.ISpatialTable;
+import org.orbisgis.orbisdata.datamanager.api.dsl.IResultSetBuilder;
 
 import javax.sql.DataSource;
 import java.io.File;
@@ -1012,4 +1013,12 @@ public interface IJdbcDataSource extends IDataSource<ResultSet>, GroovyObject, D
      * @return String SQL query.
      */
     String asSql(GString gString, List<Object> params);
+
+
+    /**
+     * Enables auto-commit mode, which means that each statement is once again
+     * committed automatically when it is completed.
+     * @param autoCommit false to disable auto-commit mode
+     */
+    IJdbcDataSource autoCommit(boolean autoCommit);
 }

--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dsl/IResultSetBuilder.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dsl/IResultSetBuilder.java
@@ -173,14 +173,6 @@ public interface IResultSetBuilder {
 
 
     /**
-     * Enables auto-commit mode, which means that each statement is once again
-     * committed automatically when it is completed.
-     * @param autoCommit false to disable auto-commit mode
-     * @return  This builder.
-     */
-    IResultSetBuilder autoCommit(boolean autoCommit);
-
-    /**
      * See {@link java.sql.Statement#execute(String)}
      */
     boolean execute(String sql) throws SQLException;

--- a/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dsl/IResultSetBuilder.java
+++ b/data-manager/api/src/main/java/org/orbisgis/orbisdata/datamanager/api/dsl/IResultSetBuilder.java
@@ -171,6 +171,15 @@ public interface IResultSetBuilder {
      */
     IResultSetBuilder maxFieldSize(int size);
 
+
+    /**
+     * Enables auto-commit mode, which means that each statement is once again
+     * committed automatically when it is completed.
+     * @param autoCommit false to disable auto-commit mode
+     * @return  This builder.
+     */
+    IResultSetBuilder autoCommit(boolean autoCommit);
+
     /**
      * See {@link java.sql.Statement#execute(String)}
      */

--- a/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/datasource/IJdbcDataSourceTest.java
+++ b/data-manager/api/src/test/java/org/orbisgis/orbisdata/datamanager/api/datasource/IJdbcDataSourceTest.java
@@ -596,6 +596,11 @@ public class IJdbcDataSourceTest {
             return null;
         }
 
+        @Override
+        public IJdbcDataSource autoCommit(boolean autoCommit) {
+            return this;
+        }
+
         @NotNull
         @Override
         public IDataSourceLocation getLocation() {

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSource.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSource.java
@@ -340,11 +340,6 @@ public abstract class JdbcDataSource extends Sql implements IJdbcDataSource, IRe
     }
 
     @Override
-    public IResultSetBuilder autoCommit(boolean autoCommit) {
-        return new ResultSetBuilder(this).autoCommit(autoCommit);
-    }
-
-    @Override
     public IResultSetBuilder timeout(int time) {
         return new ResultSetBuilder(this).timeout(time);
     }
@@ -1066,5 +1061,22 @@ public abstract class JdbcDataSource extends Sql implements IJdbcDataSource, IRe
                 preparedStatement.setObject(i, param);
             }
         }
+    }
+
+    @Override
+    public JdbcDataSource autoCommit(boolean autoCommit) {
+        try {
+            Connection con = getConnection();
+            if(con != null){
+                con.setAutoCommit(autoCommit);
+                return this;
+            }
+            else {
+                LOGGER.error("Unable to get the connection.");
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Unable to set the auto-commit mode.\n" + e.getLocalizedMessage());
+        }
+        return this;
     }
 }

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSource.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSource.java
@@ -340,6 +340,11 @@ public abstract class JdbcDataSource extends Sql implements IJdbcDataSource, IRe
     }
 
     @Override
+    public IResultSetBuilder autoCommit(boolean autoCommit) {
+        return new ResultSetBuilder(this).autoCommit(autoCommit);
+    }
+
+    @Override
     public IResultSetBuilder timeout(int time) {
         return new ResultSetBuilder(this).timeout(time);
     }

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTable.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcTable.java
@@ -503,7 +503,7 @@ public abstract class JdbcTable<T extends ResultSet, U> extends DefaultResultSet
         if (tableLocation == null) {
            query = getBaseQuery();
         } else  {
-           query =  tableLocation.toString(getDbType());
+           query =  "SELECT * FROM "+tableLocation.toString(getDbType());
         }
         try {
             ResultSet rowCountRs = con.createStatement().executeQuery("SELECT COUNT(*) FROM (" + query + ") as foo");

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/dsl/BuilderResult.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/dsl/BuilderResult.java
@@ -97,7 +97,7 @@ public abstract class BuilderResult implements IBuilderResult {
     @NotNull
     @Override
     public String toString() {
-        return "(" + getQuery() + ")";
+        return "(" + getQuery() + ") as foo";
     }
 
     @Override

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/dsl/ResultSetBuilder.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/dsl/ResultSetBuilder.java
@@ -67,11 +67,11 @@ public class ResultSetBuilder implements IResultSetBuilder {
     /**
      * {@link ResultSet} type.
      */
-    private int type = ResultSet.TYPE_FORWARD_ONLY;
+    private int type = -1;
     /**
      * {@link ResultSet} concurrency.
      */
-    private int concur = ResultSet.CONCUR_READ_ONLY;
+    private int concur = -1;
     /**
      * {@link ResultSet} holdability.
      */
@@ -104,7 +104,6 @@ public class ResultSetBuilder implements IResultSetBuilder {
      * Maximum size of the fields.
      */
     private int maxFieldSize = -1;
-    private boolean autoCommit =false;
 
     /**
      * Main constructor.
@@ -211,16 +210,8 @@ public class ResultSetBuilder implements IResultSetBuilder {
         return this;
     }
 
-    @Override
-    public IResultSetBuilder autoCommit(boolean autoCommit) {
-        this.autoCommit=autoCommit;
-        return this;
-    }
-
     private Statement getStatement() throws SQLException {
         Statement st;
-        dataSource.getConnection().setAutoCommit(autoCommit);
-
         if(type != -1 && concur != -1 && hold != -1) {
             st = dataSource.getConnection().createStatement(type, concur, hold);
         }
@@ -236,6 +227,7 @@ public class ResultSetBuilder implements IResultSetBuilder {
         else {
             st = dataSource.getConnection().createStatement();
         }
+
         if(direction != -1) {
             st.setFetchDirection(direction);
         }

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/dsl/ResultSetBuilder.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/dsl/ResultSetBuilder.java
@@ -67,11 +67,11 @@ public class ResultSetBuilder implements IResultSetBuilder {
     /**
      * {@link ResultSet} type.
      */
-    private int type = -1;
+    private int type = ResultSet.TYPE_FORWARD_ONLY;
     /**
      * {@link ResultSet} concurrency.
      */
-    private int concur = -1;
+    private int concur = ResultSet.CONCUR_READ_ONLY;
     /**
      * {@link ResultSet} holdability.
      */
@@ -104,6 +104,7 @@ public class ResultSetBuilder implements IResultSetBuilder {
      * Maximum size of the fields.
      */
     private int maxFieldSize = -1;
+    private boolean autoCommit =false;
 
     /**
      * Main constructor.
@@ -210,8 +211,16 @@ public class ResultSetBuilder implements IResultSetBuilder {
         return this;
     }
 
+    @Override
+    public IResultSetBuilder autoCommit(boolean autoCommit) {
+        this.autoCommit=autoCommit;
+        return this;
+    }
+
     private Statement getStatement() throws SQLException {
         Statement st;
+        dataSource.getConnection().setAutoCommit(autoCommit);
+
         if(type != -1 && concur != -1 && hold != -1) {
             st = dataSource.getConnection().createStatement(type, concur, hold);
         }

--- a/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/postgis/POSTGIS.java
+++ b/data-manager/jdbc/src/main/java/org/orbisgis/orbisdata/datamanager/jdbc/postgis/POSTGIS.java
@@ -213,10 +213,9 @@ public class POSTGIS extends JdbcDataSource {
             location = null;
         }
         try {
-            Connection con = getConnection();
-            if(con != null){
+            if(connection != null){
                 if(location != null){
-                    if(GeometryTableUtilities.hasGeometryColumn(con, location)) {
+                    if(GeometryTableUtilities.hasGeometryColumn(connection, location)) {
                         return new PostgisSpatialTable(location, query, statement, params, this);
                     }
                     else {

--- a/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyH2GISTest.groovy
+++ b/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyH2GISTest.groovy
@@ -840,14 +840,14 @@ class GroovyH2GISTest {
         ]
         def postGIS = POSTGIS.open(dbProperties)
         if(postGIS) {
-            h2GIS.getSpatialTable("H2GIS").save(postGIS, true);
+            h2GIS.getSpatialTable("h2gis").save(postGIS, true);
             def concat = ""
-            postGIS.spatialTable "h2gis" eachRow { row -> concat += "$row.id $row.the_geom $row.geometry\n" }
+            postGIS.spatialTable "\"H2GIS\"" eachRow { row -> concat += "$row.id $row.the_geom $row.geometry\n" }
             assertEquals("1 POINT (10 10) POINT (10 10)\n2 POINT (1 1) POINT (1 1)\n", concat)
             concat = ""
-            postGIS.execute("DROP TABLE IF EXISTS \"H2GIS\" ")
+            postGIS.execute("DROP TABLE IF EXISTS \"H2GIS\"")
             h2GIS.getSpatialTable("h2gis").save(postGIS)
-            postGIS.spatialTable "h2gis" eachRow { row -> concat += "$row.id $row.the_geom $row.geometry\n" }
+            postGIS.spatialTable "\"H2GIS\"" eachRow { row -> concat += "$row.id $row.the_geom $row.geometry\n" }
             assertEquals("1 POINT (10 10) POINT (10 10)\n2 POINT (1 1) POINT (1 1)\n", concat)
         }
     }

--- a/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyPostGISTest.groovy
+++ b/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyPostGISTest.groovy
@@ -46,6 +46,9 @@ import org.locationtech.jts.io.WKTReader
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
 import org.orbisgis.orbisdata.datamanager.jdbc.postgis.POSTGIS
 
+import java.sql.ResultSet
+import java.sql.Statement
+
 import static org.junit.jupiter.api.Assertions.*
 
 class GroovyPostGISTest {
@@ -473,4 +476,15 @@ class GroovyPostGISTest {
         postGIS.getSpatialTable("orbisgis").the_geom.dropIndex();
         assertFalse(postGIS.getSpatialTable("orbisgis").the_geom.isIndexed())
     }
-}
+
+    @Test
+    void preparedQueryTestWithFetch() {
+        postGIS.execute("""
+                DROP TABLE IF EXISTS big_geo;
+                CREATE TABLE big_geo as select st_makepoint(-60 + n*random()/500.00, 30 + n*random()/500.00), n as id from generate_series(1,100000) as n;
+        """)
+        def spatialTable = postGIS.autoCommit(false).fetchSize(100).getSpatialTable("(select * from big_geo)");
+        assertEquals(100000, spatialTable.getRowCount());
+    }
+
+    }

--- a/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyPostGISTest.groovy
+++ b/data-manager/jdbc/src/test/groovy/org/orbisgis/orbisdata/datamanager/jdbc/GroovyPostGISTest.groovy
@@ -46,9 +46,6 @@ import org.locationtech.jts.io.WKTReader
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
 import org.orbisgis.orbisdata.datamanager.jdbc.postgis.POSTGIS
 
-import java.sql.ResultSet
-import java.sql.Statement
-
 import static org.junit.jupiter.api.Assertions.*
 
 class GroovyPostGISTest {
@@ -485,6 +482,6 @@ class GroovyPostGISTest {
         """)
         def spatialTable = postGIS.autoCommit(false).fetchSize(100).getSpatialTable("(select * from big_geo)");
         assertEquals(100000, spatialTable.getRowCount());
+        postGIS.autoCommit(true)
     }
-
     }

--- a/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSourceTest.java
+++ b/data-manager/jdbc/src/test/java/org/orbisgis/orbisdata/datamanager/jdbc/JdbcDataSourceTest.java
@@ -795,7 +795,6 @@ class JdbcDataSourceTest {
                 .maxFieldSize(FIELD_SIZE).getTable("TEST_H2GIS");
         assertNotNull(table);
         assertArrayEquals(new int[]{3, 3}, table.getSize());
-
         table = postgis.scrollInsensitive().readOnly().holdCursorOverCommit().fetchReverse()
                 .fetchSize(SIZE).timeout(TIMEOUT).maxRow(MAX_ROW).cursorName("name").poolable()
                 .maxFieldSize(FIELD_SIZE).getTable("test_postgis");


### PR DESCRIPTION
About https://github.com/orbisgis/orbisdata/issues/306

For large table the fetch size must be set and auto-commit mode disable.
So I added a new method to disable the auto-commit mode

getRowCount has been improved to use the sql and not the resulset