### PR TITLE
Fix getTable method on subquery

### DIFF
--- a/data/h2gis/src/test/groovy/org/orbisgis/data/GroovyH2GISTest.groovy
+++ b/data/h2gis/src/test/groovy/org/orbisgis/data/GroovyH2GISTest.groovy
@@ -1080,7 +1080,7 @@ class GroovyH2GISTest {
                 INSERT INTO h2gis VALUES (1, 'corn', 'SRID=4326;POINT(10.2322222666 10)'::GEOMETRY), (2, 'grass', 'SRID=4326;POINT(1 1)'::GEOMETRY);
         """)
         ISpatialTable table  = h2GIS.getSpatialTable("h2gis").columns("land", "st_precisionreducer(st_transform(the_geom, 4326), 3) as the_geom")
-                .filter("limit 1").getSpatialTable();
+                .filter("limit 1").getSpatialTable()
         assertEquals(1, table.getRowCount())
         assertEquals("POINT (10.232 10)", table.getExtent().getEnvelope().toString())
     }

--- a/data/jdbc/src/main/java/org/orbisgis/data/jdbc/JdbcSpatialTable.java
+++ b/data/jdbc/src/main/java/org/orbisgis/data/jdbc/JdbcSpatialTable.java
@@ -255,7 +255,12 @@ public abstract class JdbcSpatialTable extends JdbcTable<StreamSpatialResultSet>
                 }
                 Tuple<String, Integer> geomMeta=null;
                 try {
-                    geomMeta = GeometryTableUtilities.getFirstGeometryColumnNameAndIndex(con, getTableLocation());
+                    TableLocation tableLocation = getTableLocation();
+                    if (tableLocation == null) {
+                        geomMeta = GeometryTableUtilities.getFirstGeometryColumnNameAndIndex(rs0.getMetaData());
+                    }else {
+                        geomMeta = GeometryTableUtilities.getFirstGeometryColumnNameAndIndex(con, tableLocation);
+                    }
                 } catch (SQLException e) {
                     LOGGER.error("There is no geometric field.", e);
                 }

--- a/data/jdbc/src/main/java/org/orbisgis/data/jdbc/JdbcTable.java
+++ b/data/jdbc/src/main/java/org/orbisgis/data/jdbc/JdbcTable.java
@@ -521,7 +521,11 @@ public abstract class JdbcTable<T extends ResultSet> extends DefaultResultSet im
         }
         String query = "";
         if (tableLocation == null) {
-           query = "SELECT COUNT(*) FROM ("+getBaseQuery()+") AS FOO";
+            if(getBaseQuery().startsWith("(") && getBaseQuery().endsWith(")")) {
+                query= "SELECT COUNT(*) FROM " +getBaseQuery() + "AS FOO";
+            }else {
+                query = "SELECT COUNT(*) FROM (" + getBaseQuery() + ") AS FOO";
+            }
         } else  {
            query =  "SELECT count(*) FROM "+tableLocation.toString(getDbType());
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,6 @@
 ## Changelog for v2.1.0
 
 - Update H2GIS to 2.2.0
+- Fix getTable method when the user set a subquery
+eg h2GIS.getSpatialTable("h2gis").columns("land", "st_precisionreducer(st_transform(the_geom, 4326), 3) as the_geom")
+  .filter("limit 1").getSpatialTable()


### PR DESCRIPTION
The following syntax now works

```java
h2GIS.getSpatialTable("h2gis").columns("land", "st_precisionreducer(st_transform(the_geom, 4326), 3) as the_geom")
  .filter("limit 1").getSpatialTable()
```